### PR TITLE
Calico endpoint policy - remove .cloud.ibm

### DIFF
--- a/calico-policies/private-network-isolation/calico-v2/generic-privatehostendpoint.yaml
+++ b/calico-policies/private-network-isolation/calico-v2/generic-privatehostendpoint.yaml
@@ -12,7 +12,7 @@
   spec:
     # Interface name for virtual machines on the private network.
     interfaceName: eth0
-    # Run 'ibmcloud ks workers <cluster-name>' to see worker nodes' private IPs
+    # Run 'ibmcloud ks workers --cluster <cluster-name>' to see worker nodes' private IPs
     expectedIPs:
     - <worker-node-private-ip>
 
@@ -30,7 +30,7 @@
   spec:
     # Interface name for virtual machines on the private network.
     interfaceName: eth0
-    # Run 'ibmcloud ks workers <cluster-name>' to see worker nodes' private IPs
+    # Run 'ibmcloud ks workers --cluster <cluster-name>' to see worker nodes' private IPs
     expectedIPs:
     - <worker-node-private-ip>
 

--- a/calico-policies/private-network-isolation/calico-v2/generic-privatehostendpoint.yaml
+++ b/calico-policies/private-network-isolation/calico-v2/generic-privatehostendpoint.yaml
@@ -6,31 +6,31 @@
   metadata:
     labels:
       ibm.role: worker_private
-    # run ibmcloud ks workers <cluster-name> to see worker node names
+    # Run 'calicoctl get nodes' to see Calico-formatted worker node names
     name: <worker_name>_worker_private
-    node: <worker_name>.cloud.ibm
+    node: <worker_name>
   spec:
     # Interface name for virtual machines on the private network.
     interfaceName: eth0
-    # Worker node private IP
+    # Run 'ibmcloud ks workers <cluster-name>' to see worker nodes' private IPs
     expectedIPs:
     - <worker-node-private-ip>
-    
+
 ---
 
-# worker node 2  
+# worker node 2
 - apiVersion: v1
   kind: hostEndpoint
   metadata:
     labels:
       ibm.role: worker_private
-    # run ibmcloud ks workers <cluster-name> to see worker node names
+    # Run 'calicoctl get nodes' to see Calico-formatted worker node names
     name: <worker_name>_worker_private
-    node: <worker_name>.cloud.ibm
+    node: <worker_name>
   spec:
     # Interface name for virtual machines on the private network.
     interfaceName: eth0
-    # Worker node private IP
+    # Run 'ibmcloud ks workers <cluster-name>' to see worker nodes' private IPs
     expectedIPs:
     - <worker-node-private-ip>
 

--- a/calico-policies/private-network-isolation/calico-v3/generic-privatehostendpoint.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/generic-privatehostendpoint.yaml
@@ -12,7 +12,7 @@ spec:
   node: <worker-node-name>
   # Interface name for virtual machines on the private network.
   interfaceName: eth0
-  # Run 'ibmcloud ks workers <cluster-name>' to see worker nodes' private IPs
+  # Run 'ibmcloud ks workers --cluster <cluster-name>' to see worker nodes' private IPs
   expectedIPs:
   - <worker-node-private-ip>
 
@@ -30,7 +30,7 @@ spec:
   node: <worker-node-name>
   # Interface name for virtual machines on the private network.
   interfaceName: eth0
-  # Run 'ibmcloud ks workers <cluster-name>' to see worker nodes' private IPs
+  # Run 'ibmcloud ks workers --cluster <cluster-name>' to see worker nodes' private IPs
   expectedIPs:
   - <worker-node-private-ip>
 

--- a/calico-policies/private-network-isolation/calico-v3/generic-privatehostendpoint.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/generic-privatehostendpoint.yaml
@@ -6,32 +6,32 @@ kind: HostEndpoint
 metadata:
   labels:
     ibm.role: worker_private
-  # run ibmcloud ks workers <cluster-name> to see worker node name and private IP
+  # Run 'calicoctl get nodes' to see Calico-formatted worker node names
   name: <worker-node-name>-worker-private
 spec:
-  node: <worker-node-name>.cloud.ibm
+  node: <worker-node-name>
   # Interface name for virtual machines on the private network.
   interfaceName: eth0
-  # Worker node private IP
+  # Run 'ibmcloud ks workers <cluster-name>' to see worker nodes' private IPs
   expectedIPs:
   - <worker-node-private-ip>
-    
+
 ---
-  
+
 # worker node 2
 apiVersion: projectcalico.org/v3
 kind: HostEndpoint
 metadata:
   labels:
     ibm.role: worker_private
-  # run ibmcloud ks workers <cluster-name> to see worker node name and private IP
+  # Run 'calicoctl get nodes' to see Calico-formatted worker node names
   name: <worker-node-name>-worker-private
 spec:
-  node: <worker-node-name>.cloud.ibm
+  node: <worker-node-name>
   # Interface name for virtual machines on the private network.
   interfaceName: eth0
-  # Worker node private IP
+  # Run 'ibmcloud ks workers <cluster-name>' to see worker nodes' private IPs
   expectedIPs:
   - <worker-node-private-ip>
-  
+
 # If you have additional worker nodes, copy the above hostEndpoint and fill in appropriate values.


### PR DESCRIPTION
New ubuntu 18 workers/series 3 workers, machine type b3c.4x16 are named slightly differently and will have a host name of the form: stage-dal10-cr<CLUSTER_ID>-w1 instead of stage-dal10-cr<CLUSTER_ID>-w1.cloud.ibm (so no .cloud.ibm at the end). https://github.ibm.com/alchemy-containers/armada-network/issues/1463

Removed the .cloud.ibm part and added comment to run calicoctl get nodes in order to see the proper name structure. Also updated the IKS docs in a PR here: https://github.ibm.com/alchemy-containers/documentation/pull/3247/files#diff-7be61e8577a9259e3cae9c81171fd328R474

Can be merged whenever.