### PR TITLE
Adding the selector field to apps/v1 spec

### DIFF
--- a/daemonset-sample/norootsquash.yaml
+++ b/daemonset-sample/norootsquash.yaml
@@ -8,6 +8,9 @@ metadata:
     tier: management
     app: norootsquash
 spec:
+  selector:
+    matchLabels:
+      name: norootsquash
   template:
     metadata:
       labels:

--- a/deploy-apps-clusters/deploy-from-kube-gui.yaml
+++ b/deploy-apps-clusters/deploy-from-kube-gui.yaml
@@ -5,6 +5,9 @@ metadata:
   name: ibmliberty-deployment
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: ibmliberty
   template:
     metadata:
       labels:

--- a/deploy-apps-clusters/deploy-ibmliberty.yaml
+++ b/deploy-apps-clusters/deploy-ibmliberty.yaml
@@ -5,6 +5,9 @@ metadata:
   name: ibmliberty-deployment
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: ibmliberty
   template:
     metadata:
       labels:

--- a/deploy-apps-clusters/deploy-nginx.yaml
+++ b/deploy-apps-clusters/deploy-nginx.yaml
@@ -4,6 +4,9 @@ metadata:
   name: nginx-deployment
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:

--- a/deploy-apps-clusters/deploy_wasliberty.yaml
+++ b/deploy-apps-clusters/deploy_wasliberty.yaml
@@ -6,6 +6,9 @@ metadata:
   name: wasliberty
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: wasliberty
   template:
     metadata:
       labels:

--- a/deploy-apps-clusters/liberty_requiredAntiAffinity.yaml
+++ b/deploy-apps-clusters/liberty_requiredAntiAffinity.yaml
@@ -11,6 +11,9 @@ metadata:
   name: wasliberty
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: wasliberty
   template:
     metadata:
       labels:

--- a/deploy-apps-clusters/nginx_preferredAntiAffinity.yaml
+++ b/deploy-apps-clusters/nginx_preferredAntiAffinity.yaml
@@ -11,6 +11,9 @@ metadata:
   name: nginx
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:

--- a/ibm-worker-recovery/ibm-worker-recovery.yml
+++ b/ibm-worker-recovery/ibm-worker-recovery.yml
@@ -8,6 +8,10 @@
       namespace: kube-system
     spec:
       replicas: 2
+      selector:
+        matchLabels:
+          app: ibm-worker-recovery
+          nursekey: nurse
       strategy:
         type: RollingUpdate
       revisionHistoryLimit: 10

--- a/iks-workshop/storage/second-deployment.yaml
+++ b/iks-workshop/storage/second-deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: second-deployment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      run: liberty
   template:
     metadata:
       name: second-deployment

--- a/iks-workshop/storage/storage-deployment.yaml
+++ b/iks-workshop/storage/storage-deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: storage-deployment
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      run: liberty
   template:
     metadata:
       name: storage-deployment

--- a/watson-conversation-python-slackbot/bot.yaml
+++ b/watson-conversation-python-slackbot/bot.yaml
@@ -4,6 +4,9 @@ metadata:
   name: cs-bot
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: cs-bot
   template:
     metadata:
       labels:


### PR DESCRIPTION
From conversation in public slack:
https://ibm-container-service.slack.com/archives/C4G6362ER/p155388459806
6700?thread_ts=1553884397.065700&cid=C4G6362ER

You’re missing the selector under your Deployment’s spec
(https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#de
ploymentspec-v1-apps)

See the `controllers/nginx-deployment.yaml` example here:
https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#cr
eating-a-deployment
Notice the `spec.selector.matchLabels` matches the labels under
`spec.template.metadata.labels`

Required in 1.12+

Related to:
https://github.ibm.com/alchemy-containers/documentation/issues/3641