### PR TITLE
Adding new netpol example

### DIFF
--- a/k8s-network-policies/only-egress-to-kubeapiserver.yaml
+++ b/k8s-network-policies/only-egress-to-kubeapiserver.yaml
@@ -1,7 +1,7 @@
-# This policy will block all egress traffic not destined for the kube-apiserver
-# endpoints in an IKS cluster from the targeted pods in the namespace 
-# where it's applied. One reason you might use this policy would be to restrict
-# Kubernetes Operators from talking to anything but the k8s API server
+# This policy allow traffic to the kube-apiserver and blocks everything else
+# attempting to egress from the default namespace.
+# One reason you might use this policy would be to restrict Kubernetes
+# Operators from talking to anything but the k8s API server
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/k8s-network-policies/only-egress-to-kubeapiserver.yaml
+++ b/k8s-network-policies/only-egress-to-kubeapiserver.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: only-allow-egress-to-apiserver
+  namespace: default
+spec:
+  podSelector:
+    matchLabels: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+         cidr: 172.20.0.1/32
+    ports:
+    - port: 2040
+      protocol: TCP

--- a/k8s-network-policies/only-egress-to-kubeapiserver.yaml
+++ b/k8s-network-policies/only-egress-to-kubeapiserver.yaml
@@ -1,3 +1,7 @@
+# This policy will block all egress traffic not destined for the kube-apiserver
+# endpoints in an IKS cluster from the targeted pods in the namespace 
+# where it's applied. One reason you might use this policy would be to restrict
+# Kubernetes Operators from talking to anything but the k8s API server
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:


### PR DESCRIPTION
New sample shows how to block all traffic but that which is going to the in-cluster endpoint for the kube-apiserver.