### PR TITLE
Secret Sync Operator namespace check

### DIFF
--- a/secret-sync-operator/deploy/all-in-one.yaml
+++ b/secret-sync-operator/deploy/all-in-one.yaml
@@ -26,6 +26,9 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces", "pods", "replicasets"]
   verbs: ["get"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/secret-sync-operator/pkg/controller/secret/secret_controller.go
+++ b/secret-sync-operator/pkg/controller/secret/secret_controller.go
@@ -152,9 +152,9 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 	}
 
 	if namespaceMissing {
+		//if a namespace is missing then retry to sync after 5 minutes in case it gets added at a later time
 		return reconcile.Result{RequeueAfter: time.Minute * 5}, nil
 	} else {
-		//if a namespace is missing then retry to sync after 5 minutes in case it gets added at a later time
 		return reconcile.Result{}, nil
 	}
 }

--- a/secret-sync-operator/pkg/controller/secret/secret_controller.go
+++ b/secret-sync-operator/pkg/controller/secret/secret_controller.go
@@ -60,23 +60,23 @@ type ReconcileSecret struct {
 	scheme *runtime.Scheme
 }
 
-func createSecret(secret *corev1.Secret, name string, namespace string) (*corev1.Secret, error) {
+func createSecret(secret *corev1.Secret, name string, namespace string) (*corev1.Secret, error){
 	labels := map[string]string{
 		"secretsync.ibm.com/replicated-from": fmt.Sprintf("%s.%s", secret.Namespace, secret.Name),
 	}
 	annotations := map[string]string{
-		"secretsync.ibm.com/replicated-time":             time.Now().Format("Mon Jan 2 15:04:05 MST 2006"),
+		"secretsync.ibm.com/replicated-time": time.Now().Format("Mon Jan 2 15:04:05 MST 2006"),
 		"secretsync.ibm.com/replicated-resource-version": secret.ResourceVersion,
 	}
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: secret.TypeMeta.APIVersion,
-			Kind:       secret.Kind,
+			Kind: secret.Kind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Labels:      labels,
+			Name: name,
+			Namespace: namespace,
+			Labels: labels,
 			Annotations: annotations,
 		},
 		Data: secret.Data,
@@ -122,7 +122,7 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 				for _, target := range targetList {
 					targetData := strings.Split(target, "/")
 					targetSecret, err := createSecret(instance, targetData[1], targetData[0])
-					if err != nil {
+					if (err != nil){
 						return reconcile.Result{}, err
 					}
 					if valueInList(targetSecret.Namespace, namespaces) {

--- a/secret-sync-operator/pkg/controller/secret/secret_controller.go
+++ b/secret-sync-operator/pkg/controller/secret/secret_controller.go
@@ -121,7 +121,7 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 				targetList := strings.Split(tgts, ",")
 				for _, target := range targetList {
 					targetData := strings.Split(target, "/")
-					targetSecret, err := createSecret(instance, targetData[1], targetData[0])
+					targetSecret,err := createSecret(instance, targetData[1], targetData[0])
 					if (err != nil){
 						return reconcile.Result{}, err
 					}
@@ -147,10 +147,8 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 						namespaceMissing = true
 					}
 				}
-
 			}
 		}
-
 	}
 
 	if namespaceMissing {


### PR DESCRIPTION
Issue #44 fix - this PR loads a list of namespaces if the secret has the relevant annotations. The target namespace is checked to ensure it exists before creating the secret. If the namespace doesn't exist then the reconcile will bypass the missing namespace, continuing to others listed but will return the reconcile with a requeue after 5 minutes (No Namespace watcher, and this ensure that if the namespace is created then the secret will sync within 5 minutes). 

It also enhances the sample by showing how to get a list of resources using the operator, and how to requeue reconciles for the same secret. 

Feedback/Code review welcome. 