### PR TITLE
Create kube-audit-policy.yaml

### DIFF
--- a/kube-audit/kube-audit-policy.yaml
+++ b/kube-audit/kube-audit-policy.yaml
@@ -12,25 +12,25 @@ rules:
     namespaces: ["kube-system"]
     verbs: ["get"]
     resources:
-      - group: "" # core
+      - group: ""
         resources: ["configmaps"]
   - level: None
-    users: ["kubelet"] # legacy kubelet identity
+    users: ["kubelet"]
     verbs: ["get"]
     resources:
-      - group: "" # core
+      - group: ""
         resources: ["nodes"]
   - level: None
     userGroups: ["system:nodes"]
     verbs: ["get", "patch"]
     resources:
-      - group: "" # core
+      - group: ""
         resources: ["nodes"]
   - level: None
     userGroups: ["system:nodes"]
     verbs: ["get"]
     resources:
-      - group: "" # core
+      - group: ""
         resources: ["secrets"]
   - level: None
     users:
@@ -40,13 +40,13 @@ rules:
     verbs: ["get", "update"]
     namespaces: ["kube-system"]
     resources:
-      - group: "" # core
+      - group: ""
         resources: ["endpoints"]
   - level: None
     users: ["system:apiserver"]
     verbs: ["get"]
     resources:
-      - group: "" # core
+      - group: ""
         resources: ["namespaces"]
   # Don't log these read-only URLs.
   - level: None

--- a/kube-audit/kube-audit-policy.yaml
+++ b/kube-audit/kube-audit-policy.yaml
@@ -1,0 +1,105 @@
+# This policy is used by the audit webhook to collect and forward any events that are passed
+# through your Kubernetes API server to IBM Log Analysis with LogDNA. Fore more information,
+# see the docs: https://cloud.ibm.com/docs/containers?topic=containers-health#webhook_logdna
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  - level: None
+    userGroups: ["system:serviceaccounts:kube-system"]
+  - level: None
+    # Ingress controller reads `configmaps/ingress-uid` through the unsecured port.
+    users: ["system:unsecured"]
+    namespaces: ["kube-system"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["configmaps"]
+  - level: None
+    users: ["kubelet"] # legacy kubelet identity
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["nodes"]
+  - level: None
+    userGroups: ["system:nodes"]
+    verbs: ["get", "patch"]
+    resources:
+      - group: "" # core
+        resources: ["nodes"]
+  - level: None
+    userGroups: ["system:nodes"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["secrets"]
+  - level: None
+    users:
+      - system:kube-controller-manager
+      - system:kube-scheduler
+      - system:serviceaccount:kube-system:endpoint-controller
+    verbs: ["get", "update"]
+    namespaces: ["kube-system"]
+    resources:
+      - group: "" # core
+        resources: ["endpoints"]
+  - level: None
+    users: ["system:apiserver"]
+    verbs: ["get"]
+    resources:
+      - group: "" # core
+        resources: ["namespaces"]
+  # Don't log these read-only URLs.
+  - level: None
+    nonResourceURLs:
+      - /healthz*
+      - /version
+{% if k8s_release_style is version_compare('1.14', '<') %}
+      - /swagger*
+{% endif %}
+{% if k8s_release_style is version_compare('1.10', '>=') %}
+      - /openapi/v2*
+{% endif %}
+{% if k8s_release_style is version_compare('1.16', '>=') %}
+      - /readyz*
+      - /livez*
+{% endif %}
+  # Don't log events requests.
+  - level: None
+    resources:
+      - group: "" # core
+        resources: ["events"]
+  # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
+  # so only log at the Metadata level.
+  - level: Metadata
+    resources:
+      - group: "" # core
+        resources: ["secrets", "configmaps"]
+  # Log pod create requests to capture container images, etc.
+  - level: Request
+    verbs: ["create", "update", "patch"]
+    resources:
+    - group: "" #core
+      resources: ["pods", "replicacontrollers", "container"]
+    - group: "apps"
+      resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+    - group: "batch"
+      resources: ["jobs", "cronjobs"]
+    - group: "extensions" # necessary for pre-1.12 clusters
+      resources: ["daemonsets", "deployments", "replicasets"]
+  # Get repsonses can be large; skip them.
+  - level: Metadata
+    verbs: ["create", "update", "delete", "patch"]
+    resources:
+      - group: "" # core
+      - group: "admissionregistration.k8s.io"
+      - group: "apps"
+      - group: "authentication.k8s.io"
+      - group: "authorization.k8s.io"
+      - group: "autoscaling"
+      - group: "batch"
+      - group: "certificates.k8s.io"
+      - group: "extensions"
+      - group: "networking.k8s.io"
+      - group: "policy"
+      - group: "rbac.authorization.k8s.io"
+      - group: "settings.k8s.io"


### PR DESCRIPTION
This policy is being made available so that users know how the kube audit webhook system works in their clusters. Too long to put in the docs themselves, so hosting it here.