### PR TITLE
Sample calico policies: add openshift dns port 5353

### DIFF
--- a/calico-policies/private-network-isolation/README.md
+++ b/calico-policies/private-network-isolation/README.md
@@ -12,14 +12,14 @@ The Calico policies are organized by region. Choose the directory for the region
 
 **Worker nodes**
 * Egress network traffic on the private network interface for worker nodes is permitted to the following ports:
-  * TCP/UDP 53 for DNS
+  * TCP/UDP 53 (5353 for Openshift version 4.3 or later) for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
   * TCP/UDP 443 on 172.21.0.1 for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the private network interface for worker nodes is permitted only from subnets for IBM Cloud Infrastructure to manage worker nodes through the following ports:
-  * TCP/UDP 53 for DNS
+  * TCP/UDP 53 (5353 for Openshift version 4.3 or later) for DNS
   * TCP/UDP 52311 for Big Fix
   * 10250 for VPN communication between the Kubernetes master and worker nodes
   * ICMP to allow infrastructure health monitoring
@@ -27,7 +27,7 @@ The Calico policies are organized by region. Choose the directory for the region
 
 **Pods**
 * Egress network traffic on the private network interface for pods to private networks is denied. If worker nodes are connected to a public VLAN, pod egress is permitted to public networks. All other pod egress on the private network interface is permitted to the following ports:
-  * TCP/UDP 53 for DNS
+  * TCP/UDP 53 (5353 for Openshift version 4.3 or later) for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
   * TCP/UDP 443 on 172.21.0.1 for the Kubernetes master API server local proxy

--- a/calico-policies/private-network-isolation/README.md
+++ b/calico-policies/private-network-isolation/README.md
@@ -12,14 +12,14 @@ The Calico policies are organized by region. Choose the directory for the region
 
 **Worker nodes**
 * Egress network traffic on the private network interface for worker nodes is permitted to the following ports:
-  * TCP/UDP 53 (5353 for Openshift version 4.3 or later) for DNS
+  * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
   * TCP/UDP 443 on 172.21.0.1 for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the private network interface for worker nodes is permitted only from subnets for IBM Cloud Infrastructure to manage worker nodes through the following ports:
-  * TCP/UDP 53 (5353 for Openshift version 4.3 or later) for DNS
+  * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
   * TCP/UDP 52311 for Big Fix
   * 10250 for VPN communication between the Kubernetes master and worker nodes
   * ICMP to allow infrastructure health monitoring
@@ -27,7 +27,7 @@ The Calico policies are organized by region. Choose the directory for the region
 
 **Pods**
 * Egress network traffic on the private network interface for pods to private networks is denied. If worker nodes are connected to a public VLAN, pod egress is permitted to public networks. All other pod egress on the private network interface is permitted to the following ports:
-  * TCP/UDP 53 (5353 for Openshift version 4.3 or later) for DNS
+  * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
   * TCP/UDP 443 on 172.21.0.1 for the Kubernetes master API server local proxy

--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-egress-pods-private.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also

--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-egress-pods-private.yaml
@@ -1,5 +1,6 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 10250 for VPN communication,
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260
+# for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.
@@ -14,6 +15,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -24,6 +26,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260

--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-ibm-ports-private.yaml
@@ -1,5 +1,5 @@
 # This policy opens port 10250 for VPN communication between master and workers,
-# port 53 for DNS (5353 for Openshift 4.3 and later), port 52311 for IBM BigFix
+# port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
 # ports 443 and 3260 for communication to block storage, port 2040 and 443 on
 # 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1

--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-ibm-ports-private.yaml
@@ -1,8 +1,9 @@
 # This policy opens port 10250 for VPN communication between master and workers,
-# port 53 for DNS, port 52311 for IBM BigFix worker node updates, port 2049 for
-# communication with NFS file servers, ports 443 and 3260 for communication to
-# block storage, port 2040 and 443 on 172.21.0.1 for the master API server local
-# proxy, and port 2041 on 172.21.0.1 for the etcd local proxy.
+# port 53 for DNS (5353 for Openshift 4.3 and later), port 52311 for IBM BigFix
+# worker node updates, port 2049 forcommunication with NFS file servers,
+# ports 443 and 3260 for communication to block storage, port 2040 and 443 on
+# 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1
+# for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -14,6 +15,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -23,6 +25,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -61,6 +64,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 10250
       - 52311
     protocol: UDP
@@ -69,6 +73,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 10250
       - 52311
     protocol: TCP

--- a/calico-policies/private-network-isolation/calico-v3/eu-de/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-de/allow-egress-pods-private.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also

--- a/calico-policies/private-network-isolation/calico-v3/eu-de/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-de/allow-egress-pods-private.yaml
@@ -1,5 +1,6 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 10250 for VPN communication,
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260
+# for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.
@@ -14,6 +15,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -24,6 +26,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260

--- a/calico-policies/private-network-isolation/calico-v3/eu-de/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-de/allow-ibm-ports-private.yaml
@@ -1,5 +1,5 @@
 # This policy opens port 10250 for VPN communication between master and workers,
-# port 53 for DNS (5353 for Openshift 4.3 and later), port 52311 for IBM BigFix
+# port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
 # ports 443 and 3260 for communication to block storage, port 2040 and 443 on
 # 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1

--- a/calico-policies/private-network-isolation/calico-v3/eu-de/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-de/allow-ibm-ports-private.yaml
@@ -1,8 +1,9 @@
 # This policy opens port 10250 for VPN communication between master and workers,
-# port 53 for DNS, port 52311 for IBM BigFix worker node updates, port 2049 for
-# communication with NFS file servers, ports 443 and 3260 for communication to
-# block storage, port 2040 and 443 on 172.21.0.1 for the master API server local
-# proxy, and port 2041 on 172.21.0.1 for the etcd local proxy.
+# port 53 for DNS (5353 for Openshift 4.3 and later), port 52311 for IBM BigFix
+# worker node updates, port 2049 forcommunication with NFS file servers,
+# ports 443 and 3260 for communication to block storage, port 2040 and 443 on
+# 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1
+# for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -14,6 +15,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -23,6 +25,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -61,6 +64,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 10250
       - 52311
     protocol: UDP
@@ -69,6 +73,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 10250
       - 52311
     protocol: TCP

--- a/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-egress-pods-private.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also

--- a/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-egress-pods-private.yaml
@@ -1,5 +1,6 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 10250 for VPN communication,
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260
+# for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.
@@ -14,6 +15,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -24,6 +26,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260

--- a/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-ibm-ports-private.yaml
@@ -1,5 +1,5 @@
 # This policy opens port 10250 for VPN communication between master and workers,
-# port 53 for DNS (5353 for Openshift 4.3 and later), port 52311 for IBM BigFix
+# port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
 # ports 443 and 3260 for communication to block storage, port 2040 and 443 on
 # 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1

--- a/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-ibm-ports-private.yaml
@@ -1,8 +1,9 @@
 # This policy opens port 10250 for VPN communication between master and workers,
-# port 53 for DNS, port 52311 for IBM BigFix worker node updates, port 2049 for
-# communication with NFS file servers, ports 443 and 3260 for communication to
-# block storage, port 2040 and 443 on 172.21.0.1 for the master API server local
-# proxy, and port 2041 on 172.21.0.1 for the etcd local proxy.
+# port 53 for DNS (5353 for Openshift 4.3 and later), port 52311 for IBM BigFix
+# worker node updates, port 2049 forcommunication with NFS file servers,
+# ports 443 and 3260 for communication to block storage, port 2040 and 443 on
+# 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1
+# for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -14,6 +15,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -23,6 +25,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -61,6 +64,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 10250
       - 52311
     protocol: UDP
@@ -69,6 +73,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 10250
       - 52311
     protocol: TCP

--- a/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-egress-pods-private.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also

--- a/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-egress-pods-private.yaml
@@ -1,5 +1,6 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 10250 for VPN communication,
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260
+# for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.
@@ -14,6 +15,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -24,6 +26,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260

--- a/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-ibm-ports-private.yaml
@@ -1,5 +1,5 @@
 # This policy opens port 10250 for VPN communication between master and workers,
-# port 53 for DNS (5353 for Openshift 4.3 and later), port 52311 for IBM BigFix
+# port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
 # ports 443 and 3260 for communication to block storage, port 2040 and 443 on
 # 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1

--- a/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-ibm-ports-private.yaml
@@ -1,8 +1,9 @@
 # This policy opens port 10250 for VPN communication between master and workers,
-# port 53 for DNS, port 52311 for IBM BigFix worker node updates, port 2049 for
-# communication with NFS file servers, ports 443 and 3260 for communication to
-# block storage, port 2040 and 443 on 172.21.0.1 for the master API server local
-# proxy, and port 2041 on 172.21.0.1 for the etcd local proxy.
+# port 53 for DNS (5353 for Openshift 4.3 and later), port 52311 for IBM BigFix
+# worker node updates, port 2049 forcommunication with NFS file servers,
+# ports 443 and 3260 for communication to block storage, port 2040 and 443 on
+# 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1
+# for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -14,6 +15,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -23,6 +25,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -61,6 +64,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 10250
       - 52311
     protocol: UDP
@@ -69,6 +73,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 10250
       - 52311
     protocol: TCP

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-egress-pods-private.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-egress-pods-private.yaml
@@ -1,5 +1,6 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 10250 for VPN communication,
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260
+# for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.
@@ -14,6 +15,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -24,6 +26,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-ibm-ports-private.yaml
@@ -1,5 +1,5 @@
 # This policy opens port 10250 for VPN communication between master and workers,
-# port 53 for DNS (5353 for Openshift 4.3 and later), port 52311 for IBM BigFix
+# port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
 # ports 443 and 3260 for communication to block storage, port 2040 and 443 on
 # 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-ibm-ports-private.yaml
@@ -1,8 +1,9 @@
 # This policy opens port 10250 for VPN communication between master and workers,
-# port 53 for DNS, port 52311 for IBM BigFix worker node updates, port 2049 for
-# communication with NFS file servers, ports 443 and 3260 for communication to
-# block storage, port 2040 and 443 on 172.21.0.1 for the master API server local
-# proxy, and port 2041 on 172.21.0.1 for the etcd local proxy.
+# port 53 for DNS (5353 for Openshift 4.3 and later), port 52311 for IBM BigFix
+# worker node updates, port 2049 forcommunication with NFS file servers,
+# ports 443 and 3260 for communication to block storage, port 2040 and 443 on
+# 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1
+# for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -14,6 +15,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -23,6 +25,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -61,6 +64,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 10250
       - 52311
     protocol: UDP
@@ -69,6 +73,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 10250
       - 52311
     protocol: TCP

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-egress-pods-private.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-egress-pods-private.yaml
@@ -1,5 +1,6 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 10250 for VPN communication,
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260
+# for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.
@@ -14,6 +15,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -24,6 +26,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-ibm-ports-private.yaml
@@ -1,5 +1,5 @@
 # This policy opens port 10250 for VPN communication between master and workers,
-# port 53 for DNS (5353 for Openshift 4.3 and later), port 52311 for IBM BigFix
+# port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
 # ports 443 and 3260 for communication to block storage, port 2040 and 443 on
 # 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-ibm-ports-private.yaml
@@ -1,8 +1,9 @@
 # This policy opens port 10250 for VPN communication between master and workers,
-# port 53 for DNS, port 52311 for IBM BigFix worker node updates, port 2049 for
-# communication with NFS file servers, ports 443 and 3260 for communication to
-# block storage, port 2040 and 443 on 172.21.0.1 for the master API server local
-# proxy, and port 2041 on 172.21.0.1 for the etcd local proxy.
+# port 53 for DNS (5353 for Openshift 4.3 and later), port 52311 for IBM BigFix
+# worker node updates, port 2049 forcommunication with NFS file servers,
+# ports 443 and 3260 for communication to block storage, port 2040 and 443 on
+# 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1
+# for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -14,6 +15,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -23,6 +25,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -61,6 +64,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 10250
       - 52311
     protocol: UDP
@@ -69,6 +73,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 10250
       - 52311
     protocol: TCP

--- a/calico-policies/public-network-isolation/README.md
+++ b/calico-policies/public-network-isolation/README.md
@@ -15,14 +15,14 @@ Along with the default Calico policies that are applied to the public interface 
 **Worker nodes**
 
 * Egress network traffic on the public network interface for worker nodes is permitted to the following ports:
-  * TCP/UDP 53 (5353 for Openshift version 4.3 or later) for DNS
+  * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
   * TCP/UDP 443 on 172.21.0.1 for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the public network interface for worker nodes is permitted only from subnets for IBM Cloud infrastructure to manage worker nodes through the following ports:
-  * TCP/UDP 53 (5353 for Openshift version 4.3 or later) for DNS
+  * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
   * TCP/UDP 52311 for Big Fix
   * ICMP to allow infrastructure health monitoring
   * VRRP to use load balancer services
@@ -30,7 +30,7 @@ Along with the default Calico policies that are applied to the public interface 
 **Pods**
 
 * Egress network traffic on the public network interface for pods is permitted to the following ports:
-  * TCP/UDP 53 (5353 for Openshift version 4.3 or later) for DNS
+  * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
   * TCP/UDP 443 on 172.21.0.1 for the Kubernetes master API server local proxy

--- a/calico-policies/public-network-isolation/README.md
+++ b/calico-policies/public-network-isolation/README.md
@@ -15,14 +15,14 @@ Along with the default Calico policies that are applied to the public interface 
 **Worker nodes**
 
 * Egress network traffic on the public network interface for worker nodes is permitted to the following ports:
-  * TCP/UDP 53 for DNS
+  * TCP/UDP 53 (5353 for Openshift version 4.3 or later) for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
   * TCP/UDP 443 on 172.21.0.1 for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the public network interface for worker nodes is permitted only from subnets for IBM Cloud infrastructure to manage worker nodes through the following ports:
-  * TCP/UDP 53 for DNS
+  * TCP/UDP 53 (5353 for Openshift version 4.3 or later) for DNS
   * TCP/UDP 52311 for Big Fix
   * ICMP to allow infrastructure health monitoring
   * VRRP to use load balancer services
@@ -30,7 +30,7 @@ Along with the default Calico policies that are applied to the public interface 
 **Pods**
 
 * Egress network traffic on the public network interface for pods is permitted to the following ports:
-  * TCP/UDP 53 for DNS
+  * TCP/UDP 53 (5353 for Openshift version 4.3 or later) for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
   * TCP/UDP 443 on 172.21.0.1 for the Kubernetes master API server local proxy

--- a/calico-policies/public-network-isolation/au-syd/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-egress-pods-public.yaml
@@ -1,5 +1,6 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS
-# file servers, ports 443 and 3260 for communication to block storage, 10250 for VPN pod, and
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260
+# for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 443 on 172.21.0.1 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -12,6 +13,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -22,6 +24,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260

--- a/calico-policies/public-network-isolation/au-syd/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-egress-pods-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 443 on 172.21.0.1 for the master API server local proxy.

--- a/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
@@ -1,6 +1,7 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS file
-# servers, ports 443 and 3260 for communication to block storage, port 2040 and 443
-# for the master API server local proxy, and port 2041 for the etcd local proxy.
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260,
+# for communication to block storage, port 2040 and 443 for the master
+# API server local proxy, and port 2041 for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -12,6 +13,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -21,6 +23,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -59,6 +62,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 52311
     protocol: UDP
     source: {}
@@ -66,6 +70,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 52311
     protocol: TCP
     source: {}

--- a/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
 # for communication to block storage, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.

--- a/calico-policies/public-network-isolation/eu-de/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-egress-pods-public.yaml
@@ -1,5 +1,6 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS
-# file servers, ports 443 and 3260 for communication to block storage, 10250 for VPN pod, and
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260
+# for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 443 on 172.21.0.1 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -12,6 +13,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -22,6 +24,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260

--- a/calico-policies/public-network-isolation/eu-de/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-egress-pods-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 443 on 172.21.0.1 for the master API server local proxy.

--- a/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
@@ -1,6 +1,7 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS file
-# servers, ports 443 and 3260 for communication to block storage, port 2040 and 443
-# for the master API server local proxy, and port 2041 for the etcd local proxy.
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260,
+# for communication to block storage, port 2040 and 443 for the master
+# API server local proxy, and port 2041 for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -12,6 +13,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -21,6 +23,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -59,6 +62,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 52311
     protocol: UDP
     source: {}
@@ -66,6 +70,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 52311
     protocol: TCP
     source: {}

--- a/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
 # for communication to block storage, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.

--- a/calico-policies/public-network-isolation/eu-gb/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-egress-pods-public.yaml
@@ -1,5 +1,6 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS
-# file servers, ports 443 and 3260 for communication to block storage, 10250 for VPN pod, and
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260
+# for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 443 on 172.21.0.1 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -12,6 +13,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -22,6 +24,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260

--- a/calico-policies/public-network-isolation/eu-gb/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-egress-pods-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 443 on 172.21.0.1 for the master API server local proxy.

--- a/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
@@ -1,6 +1,7 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS file
-# servers, ports 443 and 3260 for communication to block storage, port 2040 and 443
-# for the master API server local proxy, and port 2041 for the etcd local proxy.
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260,
+# for communication to block storage, port 2040 and 443 for the master
+# API server local proxy, and port 2041 for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -12,6 +13,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -21,6 +23,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -59,6 +62,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 52311
     protocol: UDP
     source: {}
@@ -66,6 +70,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 52311
     protocol: TCP
     source: {}

--- a/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
 # for communication to block storage, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.

--- a/calico-policies/public-network-isolation/jp-tok/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-egress-pods-public.yaml
@@ -1,5 +1,6 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS
-# file servers, ports 443 and 3260 for communication to block storage, 10250 for VPN pod, and
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260
+# for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 443 on 172.21.0.1 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -12,6 +13,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -22,6 +24,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260

--- a/calico-policies/public-network-isolation/jp-tok/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-egress-pods-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 443 on 172.21.0.1 for the master API server local proxy.

--- a/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
@@ -1,6 +1,7 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS file
-# servers, ports 443 and 3260 for communication to block storage, port 2040 and 443
-# for the master API server local proxy, and port 2041 for the etcd local proxy.
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260,
+# for communication to block storage, port 2040 and 443 for the master
+# API server local proxy, and port 2041 for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -12,6 +13,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -21,6 +23,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -59,6 +62,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 52311
     protocol: UDP
     source: {}
@@ -66,6 +70,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 52311
     protocol: TCP
     source: {}

--- a/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
 # for communication to block storage, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.

--- a/calico-policies/public-network-isolation/us-east/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-egress-pods-public.yaml
@@ -1,5 +1,6 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS
-# file servers, ports 443 and 3260 for communication to block storage, 10250 for VPN pod, and
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260
+# for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 443 on 172.21.0.1 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -12,6 +13,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -22,6 +24,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260

--- a/calico-policies/public-network-isolation/us-east/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-egress-pods-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 443 on 172.21.0.1 for the master API server local proxy.

--- a/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
@@ -1,6 +1,7 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS file
-# servers, ports 443 and 3260 for communication to block storage, port 2040 and 443
-# for the master API server local proxy, and port 2041 for the etcd local proxy.
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260,
+# for communication to block storage, port 2040 and 443 for the master
+# API server local proxy, and port 2041 for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -12,6 +13,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -21,6 +23,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -59,6 +62,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 52311
     protocol: UDP
     source: {}
@@ -66,6 +70,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 52311
     protocol: TCP
     source: {}

--- a/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
 # for communication to block storage, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.

--- a/calico-policies/public-network-isolation/us-south/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-egress-pods-public.yaml
@@ -1,5 +1,6 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS
-# file servers, ports 443 and 3260 for communication to block storage, 10250 for VPN pod, and
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260
+# for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 443 on 172.21.0.1 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -12,6 +13,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -22,6 +24,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260

--- a/calico-policies/public-network-isolation/us-south/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-egress-pods-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 443 on 172.21.0.1 for the master API server local proxy.

--- a/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
@@ -1,6 +1,7 @@
-# This policy opens port 53 for DNS, port 2049 for communication with NFS file
-# servers, ports 443 and 3260 for communication to block storage, port 2040 and 443
-# for the master API server local proxy, and port 2041 for the etcd local proxy.
+# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# port 2049 for communication with NFS file servers, ports 443 and 3260,
+# for communication to block storage, port 2040 and 443 for the master
+# API server local proxy, and port 2041 for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -12,6 +13,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -21,6 +23,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 443
       - 2049
       - 3260
@@ -59,6 +62,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 52311
     protocol: UDP
     source: {}
@@ -66,6 +70,7 @@ spec:
     destination:
       ports:
       - 53
+      - 5353
       - 52311
     protocol: TCP
     source: {}

--- a/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for Openshift 4.3 and later),
+# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
 # for communication to block storage, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.


### PR DESCRIPTION
https://github.ibm.com/alchemy-containers/armada-network/issues/2765