### PR TITLE
Update version of the stranger image

### DIFF
--- a/gateway-clusters/ibm-external-compute-job.yaml
+++ b/gateway-clusters/ibm-external-compute-job.yaml
@@ -72,7 +72,7 @@ spec:
       - name: ibm-external-compute-image-pull
       containers:
       - name: provision
-        image: &image us.icr.io/armada-master/stranger:v1.0.3
+        image: &image us.icr.io/armada-master/stranger:v1.0.4
         env:
         - name: IMAGE_URL
           value: *image


### PR DESCRIPTION
The new image version includes ansible 2.8.8 which fixes the following vulnerability issues:
 CVE-2019-14864
 CVE-2019-14904
 CVE-2019-14905

Testing was successful based on the official documentation.