### PR TITLE
add 10.10.10.1 for 2+ y.o. clusters

### DIFF
--- a/calico-policies/private-network-isolation/README.md
+++ b/calico-policies/private-network-isolation/README.md
@@ -17,7 +17,7 @@ The Calico policies are organized by region. Choose the directory for the region
   * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
-  * TCP/UDP 443 on 172.21.0.1 for the Kubernetes master API server local proxy
+  * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the private network interface for worker nodes is permitted only from subnets for IBM Cloud Infrastructure to manage worker nodes through the following ports:
@@ -32,7 +32,7 @@ The Calico policies are organized by region. Choose the directory for the region
   * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
-  * TCP/UDP 443 on 172.21.0.1 for the Kubernetes master API server local proxy
+  * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * TCP/UDP 20000:32767 and 443 for communication with the Kubernetes master
   * Specified ports for other IBM Cloud services

--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-ibm-ports-private.yaml
@@ -1,9 +1,9 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 2040 and 443 on
-# 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1
-# for the etcd local proxy.
+# ports 443 and 3260 for communication to block storage, port 2040 and 2041 on
+# 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
+# (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy

--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-ibm-ports-private.yaml
@@ -50,14 +50,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: TCP
   ingress:
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/eu-de/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-de/allow-ibm-ports-private.yaml
@@ -1,9 +1,9 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 2040 and 443 on
-# 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1
-# for the etcd local proxy.
+# ports 443 and 3260 for communication to block storage, port 2040 and 2041 on
+# 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
+# (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy

--- a/calico-policies/private-network-isolation/calico-v3/eu-de/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-de/allow-ibm-ports-private.yaml
@@ -50,14 +50,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: TCP
   ingress:
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-ibm-ports-private.yaml
@@ -1,9 +1,9 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 2040 and 443 on
-# 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1
-# for the etcd local proxy.
+# ports 443 and 3260 for communication to block storage, port 2040 and 2041 on
+# 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
+# (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy

--- a/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-ibm-ports-private.yaml
@@ -50,14 +50,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: TCP
   ingress:
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-ibm-ports-private.yaml
@@ -50,14 +50,15 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
-      nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: TCP
   ingress:
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-ibm-ports-private.yaml
@@ -1,9 +1,9 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 2040 and 443 on
-# 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1
-# for the etcd local proxy.
+# ports 443 and 3260 for communication to block storage, port 2040 and 2041 on
+# 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
+# (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -57,6 +57,7 @@ spec:
     destination:
       ports:
       - 443
+      nets:
       - 172.21.0.1/32 # For clusters created <2 years ago
       - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: TCP

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-ibm-ports-private.yaml
@@ -1,9 +1,9 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 2040 and 443 on
-# 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1
-# for the etcd local proxy.
+# ports 443 and 3260 for communication to block storage, port 2040 and 2041 on
+# 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
+# (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-ibm-ports-private.yaml
@@ -50,14 +50,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: TCP
   ingress:
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-ibm-ports-private.yaml
@@ -1,9 +1,9 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 2040 and 443 on
-# 172.21.0.1 for the master API server local proxy, and port 2041 on 172.21.0.1
-# for the etcd local proxy.
+# ports 443 and 3260 for communication to block storage, port 2040 and 2041 on
+# 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
+# (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-ibm-ports-private.yaml
@@ -50,14 +50,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: TCP
   ingress:
   - action: Allow

--- a/calico-policies/public-network-isolation/README.md
+++ b/calico-policies/public-network-isolation/README.md
@@ -20,7 +20,7 @@ Along with the default Calico policies that are applied to the public interface 
   * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
-  * TCP/UDP 443 on 172.21.0.1 for the Kubernetes master API server local proxy
+  * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the public network interface for worker nodes is permitted only from subnets for IBM Cloud infrastructure to manage worker nodes through the following ports:
@@ -35,7 +35,7 @@ Along with the default Calico policies that are applied to the public interface 
   * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
-  * TCP/UDP 443 on 172.21.0.1 for the Kubernetes master API server local proxy
+  * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * TCP/UDP 20000:32767 and 443 for communication with the Kubernetes master
   * Specified ports for other IBM Cloud services

--- a/calico-policies/public-network-isolation/au-syd/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, 10250 for VPN pod, and
-# port 2040 and 443 on 172.21.0.1 for the master API server local proxy.
+# port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy

--- a/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
@@ -34,14 +34,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: TCP
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/eu-de/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, 10250 for VPN pod, and
-# port 2040 and 443 on 172.21.0.1 for the master API server local proxy.
+# port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy

--- a/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
@@ -34,14 +34,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: TCP
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/eu-gb/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, 10250 for VPN pod, and
-# port 2040 and 443 on 172.21.0.1 for the master API server local proxy.
+# port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy

--- a/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
@@ -34,14 +34,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: TCP
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/jp-tok/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, 10250 for VPN pod, and
-# port 2040 and 443 on 172.21.0.1 for the master API server local proxy.
+# port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy

--- a/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
@@ -34,14 +34,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: TCP
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/us-east/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage 10250 for VPN pod, and
-# port 2040 and 443 on 172.21.0.1 for the master API server local proxy.
+# port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy

--- a/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
@@ -34,14 +34,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: TCP
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/us-south/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage 10250 for VPN pod, and
-# port 2040 and 443 on 172.21.0.1 for the master API server local proxy.
+# port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy

--- a/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
@@ -34,14 +34,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32
+      - 172.21.0.1/32 # For clusters created <2 years ago
+      - 10.10.10.1/32 # For clusters created >2 years ago
     protocol: TCP
   - action: Allow
     destination:


### PR DESCRIPTION
Clusters that were created more than about 2 years ago use 10.10.10.1 instead of 172.21.0.1 service IP

See thread: https://ibm-argonauts.slack.com/archives/C4S4NUCB1/p1585582078290500?thread_ts=1585057031.387700&cid=C4S4NUCB1