### PR TITLE
Vulnerability issue in ansible

### DIFF
--- a/gateway-clusters/ibm-external-compute-job.yaml
+++ b/gateway-clusters/ibm-external-compute-job.yaml
@@ -72,7 +72,7 @@ spec:
       - name: ibm-external-compute-image-pull
       containers:
       - name: provision
-        image: &image us.icr.io/armada-master/stranger:v1.0.5
+        image: &image us.icr.io/armada-master/stranger:v1.0.6
         env:
         - name: IMAGE_URL
           value: *image

--- a/gateway-clusters/ibm-external-compute-job.yaml
+++ b/gateway-clusters/ibm-external-compute-job.yaml
@@ -72,7 +72,7 @@ spec:
       - name: ibm-external-compute-image-pull
       containers:
       - name: provision
-        image: &image us.icr.io/armada-master/stranger:v1.0.4
+        image: &image us.icr.io/armada-master/stranger:v1.0.5
         env:
         - name: IMAGE_URL
           value: *image


### PR DESCRIPTION
Update to ansible 2.8.11
Fixes the following issues:
CVE-2020-1967
CVE-2019-3828
CVE-2020-1733
CVE-2020-1740
CVE-2020-1737
CVE-2020-1739
