### PR TITLE
Update image and va fixes

### DIFF
--- a/secret-sync-operator/Dockerfile
+++ b/secret-sync-operator/Dockerfile
@@ -13,7 +13,7 @@ RUN PATH=$GOPATH/bin:$PATH go build -o build/_output/bin/secret-sync-operator cm
 
 
 
-FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:7.6
+FROM registry.access.redhat.com/ubi8-minimal
 ENV OPERATOR=/usr/local/bin/secret-sync-operator \
     USER_UID=1001 \
     USER_NAME=secret-sync-operator
@@ -21,6 +21,7 @@ ENV OPERATOR=/usr/local/bin/secret-sync-operator \
 COPY --from=0 /go/src/github.com/ibm/secret-sync-operator/build/_output/bin/secret-sync-operator ${OPERATOR}
 COPY --from=0 /go/src/github.com/ibm/secret-sync-operator/build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
+# vulnerability advisor fix
+RUN microdnf install -y shared-mime-info
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 USER ${USER_UID}
-


### PR DESCRIPTION
Updates base image and applies va fixes.

Output of `ibmcloud cr va <image_name>`:
```
Image '<image_name>' was last scanned on Tue Apr 21 19:50:53 UTC 2020
The scan results show that NO ISSUES were found for the image.

OK
```