### PR TITLE
53 and 5353 needed for dns

### DIFF
--- a/calico-policies/private-network-isolation/README.md
+++ b/calico-policies/private-network-isolation/README.md
@@ -14,14 +14,14 @@ The Calico policies are organized by region. Choose the directory for the region
 
 **Worker nodes**
 * Egress network traffic on the private network interface for worker nodes is permitted to the following ports:
-  * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
+  * TCP/UDP 53 and 5353 for OpenShift version 4.3 or later for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
   * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the private network interface for worker nodes is permitted only from subnets for IBM Cloud Infrastructure to manage worker nodes through the following ports:
-  * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
+  * TCP/UDP 53 and 5353 for OpenShift version 4.3 or later for DNS
   * TCP/UDP 52311 for Big Fix
   * 10250 for VPN communication between the Kubernetes master and worker nodes
   * ICMP to allow infrastructure health monitoring
@@ -29,7 +29,7 @@ The Calico policies are organized by region. Choose the directory for the region
 
 **Pods**
 * Egress network traffic on the private network interface for pods to private networks is denied. If worker nodes are connected to a public VLAN, pod egress is permitted to public networks. All other pod egress on the private network interface is permitted to the following ports:
-  * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
+  * TCP/UDP 53 and 5353 for OpenShift version 4.3 or later for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
   * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy

--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-egress-pods-private.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also

--- a/calico-policies/private-network-isolation/calico-v3/eu-de/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-de/allow-egress-pods-private.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also

--- a/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-egress-pods-private.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also

--- a/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-egress-pods-private.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-egress-pods-private.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-egress-pods-private.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, port 10250 for VPN communication,
 # and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also

--- a/calico-policies/public-network-isolation/README.md
+++ b/calico-policies/public-network-isolation/README.md
@@ -17,14 +17,14 @@ Along with the default Calico policies that are applied to the public interface 
 **Worker nodes**
 
 * Egress network traffic on the public network interface for worker nodes is permitted to the following ports:
-  * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
+  * TCP/UDP 53 and 5353 for OpenShift version 4.3 or later for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
   * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the public network interface for worker nodes is permitted only from subnets for IBM Cloud infrastructure to manage worker nodes through the following ports:
-  * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
+  * TCP/UDP 53 and 5353 for OpenShift version 4.3 or later for DNS
   * TCP/UDP 52311 for Big Fix
   * ICMP to allow infrastructure health monitoring
   * VRRP to use load balancer services
@@ -32,7 +32,7 @@ Along with the default Calico policies that are applied to the public interface 
 **Pods**
 
 * Egress network traffic on the public network interface for pods is permitted to the following ports:
-  * TCP/UDP 53 (5353 for OpenShift version 4.3 or later) for DNS
+  * TCP/UDP 53 and 5353 for OpenShift version 4.3 or later for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
   * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy

--- a/calico-policies/public-network-isolation/au-syd/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-egress-pods-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.

--- a/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
 # for communication to block storage, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.

--- a/calico-policies/public-network-isolation/eu-de/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-egress-pods-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.

--- a/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
 # for communication to block storage, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.

--- a/calico-policies/public-network-isolation/eu-gb/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-egress-pods-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.

--- a/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
 # for communication to block storage, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.

--- a/calico-policies/public-network-isolation/jp-tok/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-egress-pods-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage, 10250 for VPN pod, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.

--- a/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
 # for communication to block storage, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.

--- a/calico-policies/public-network-isolation/us-east/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-egress-pods-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage 10250 for VPN pod, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.

--- a/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
 # for communication to block storage, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.

--- a/calico-policies/public-network-isolation/us-south/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-egress-pods-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
 # for communication to block storage 10250 for VPN pod, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.

--- a/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
@@ -1,4 +1,4 @@
-# This policy opens port 53 for DNS (5353 for OpenShift 4.3 and later),
+# This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
 # for communication to block storage, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.


### PR DESCRIPTION
Previously thought that DNS port for IKS and for openshift 3.11 was 53, and for openshift 4.3+ was 5353. 

Due to some investigations w a [customer ticket](https://github.ibm.com/alchemy-containers/customer-tickets/issues/5447), it was discovered that for openshift 4.3+, both 53 and 5353 are needed. 

Both ports are already listed in the policies; just updated the documentation. Also updated [upstream ](https://github.ibm.com/alchemy-containers/documentation/commit/513b9ec87e41c4e2c7916fc953860f06a14a1204)ROKS docs
