### PR TITLE
Update ibm-external-compute-job.yaml

### DIFF
--- a/gateway-clusters/ibm-external-compute-job.yaml
+++ b/gateway-clusters/ibm-external-compute-job.yaml
@@ -72,7 +72,7 @@ spec:
       - name: ibm-external-compute-image-pull
       containers:
       - name: provision
-        image: &image us.icr.io/armada-master/stranger:v1.0.9
+        image: &image us.icr.io/armada-master/stranger:v1.0.14
         env:
         - name: IMAGE_URL
           value: *image


### PR DESCRIPTION
To have latest ansible installed to mitigate CVE-2020-14365.