### PR TITLE
Add iks-life-preserver terraform code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*

--- a/iks-life-preserver/README.md
+++ b/iks-life-preserver/README.md
@@ -1,6 +1,6 @@
 # iks-life-preserver
 
-## What is this?
+## About
 The Life Preserver project uses IBM Cloud Schematics to 
 quickly invite a member of IBM Cloud Support to your IBM 
 Cloud account. With this temporary access, IBM Cloud Support 

--- a/iks-life-preserver/README.md
+++ b/iks-life-preserver/README.md
@@ -22,7 +22,7 @@ Follow the steps below to invite a user to your account and grant them:
 
 ### Step 2 
 
-Browse to the IBM Cloud Schematics offering at https://cloud.ibm.com/schematics
+[Open the IBM Cloud Schematics dashboard.](https://cloud.ibm.com/schematics)
 
 ### Step 3
 

--- a/iks-life-preserver/README.md
+++ b/iks-life-preserver/README.md
@@ -62,6 +62,6 @@ At this point, if the `apply` operation was successful you should be able to bro
 From the main workspace page, click on the `Actions` drop-down button near the top-right part of the screen and select `Delete`:
 
 * To remove all changes and delete the workspace completely, select both checkboxes.
-* If you want to remove all the changes and keep the workspace around for re-use at a later time, just check the second box. 
+* To remove all changes and keep the workspace for re-use at a later time, select only the second checkbox. 
 
 Confirm the operation by typing in the workspace name and then clicking `Delete`

--- a/iks-life-preserver/README.md
+++ b/iks-life-preserver/README.md
@@ -1,0 +1,67 @@
+# iks-life-preserver
+
+## What is this?
+Life Preserver is a simple project designed to be used with the 
+IBM Cloud Schematics service to make the process of inviting 
+someone to your IBM Cloud account for the purpose of helping you 
+troubleshoot issues with your IBM Cloud Kubernetes Service Clusters
+ (including OpenShift on IBM Cloud clusters).
+
+## How it works
+Follow the steps below to invite a user to your account and grant them: 
+
+* A `Viewer` IAM platform policy that allows the user to see only Kubernetes and OpenShift clusters
+* A `Reader` IAM service policy that allows the user to have **view-only** access to the **specific cluster you grant them access to**. 
+
+> Note: In terms of Kubernetes RBAC, this user will not have access to any Secrets or RBAC resources inside the cluster.
+
+
+### Step 1
+
+ Login to the IBM Cloud web console at https://cloud.ibm.com.
+
+### Step 2 
+
+Browse to the IBM Cloud Schematics offering at https://cloud.ibm.com/schematics
+
+### Step 3
+
+Click `Create workspace` and give your new workspace a relevant name and pick a location and click `Create`. 
+
+### Step 4
+
+Now you should be looking at your workspace settings. Provide `https://github.com/jpapejr/iks-life-preserver/tree/main` as the Terraform template URL and ensure that you choose a Terraform version of 0.12 or higher for this workspace. Click `Save template information` to save your changes. Wait for the system import and process the Terraform data before continuing.
+
+### Step 5
+
+You should now see four variables that need to be populated before continuing:
+
+* `reference` - This is a user-defined reference that will be appeanded to the generated service ID name for purpose reference.
+* `cluster` - This is the **cluster ID** of the specific cluster to grant **read-only** access to.
+* `apikey` - This is an IBM Cloud API Key with sufficient privileges to invite new members to the account. For security purposes, ensure you check the `Sensitive` box on the far right so your key is obscured from view after it input.
+* `account` - This is the target account within which the operations will occur. 
+
+When done, click `Save changes`.
+
+### Step 6
+
+At the top of the screen click on the `Generate plan` button. Ensure it completes successfully before moving on. Address any Terraform errors that might arise due to back API Key or cluster ID values. 
+
+### Step 7
+
+Again, at the top of the screen, click on the `Apply plan` button. Once the `apply` operation has completed, you can click on `View Logs` to find the generated Service ID API Key. Share this securely with the individual providing assistance; they will be able to authenticate using this API Key for the targeted account & cluster resources as defined above. 
+
+### Step 8
+
+At this point, if the `apply` operation was successful you should be able to browse into the [IAM portion of the console](https://cloud.ibm.com/iam/users) to confirm the access. 
+
+
+
+### Step 9 (roll-back/revert the process)
+
+From the main workspace page, click on the `Actions` drop-down button near the top-right part of the screen and select `Delete`:
+
+* If you want to remove all the changes and delete the workspace completely, check both boxes.
+* If you want to remove all the changes and keep the workspace around for re-use at a later time, just check the second box. 
+
+Confirm the operation by typing in the workspace name and then clicking `Delete`

--- a/iks-life-preserver/README.md
+++ b/iks-life-preserver/README.md
@@ -1,11 +1,11 @@
 # iks-life-preserver
 
 ## What is this?
-Life Preserver is a simple project designed to be used with the 
-IBM Cloud Schematics service to make the process of inviting 
-someone to your IBM Cloud account for the purpose of helping you 
-troubleshoot issues with your IBM Cloud Kubernetes Service Clusters
- (including OpenShift on IBM Cloud clusters).
+The Life Preserver project uses IBM Cloud Schematics to 
+quickly invite a member of IBM Cloud Support to your IBM 
+Cloud account. With this temporary access, IBM Cloud Support 
+can help you troubleshoot issues with your IBM Cloud Kubernetes 
+Service and Red Hat OpenShift on IBM Cloud clusters.
 
 ## How it works
 Follow the steps below to invite a user to your account and grant them: 

--- a/iks-life-preserver/README.md
+++ b/iks-life-preserver/README.md
@@ -26,7 +26,7 @@ Follow the steps below to invite a user to your account and grant them:
 
 ### Step 3
 
-Click `Create workspace` and give your new workspace a relevant name and pick a location and click `Create`. 
+Click **Create Workspace**. Enter a name, select a location, and click **Create**.
 
 ### Step 4
 

--- a/iks-life-preserver/README.md
+++ b/iks-life-preserver/README.md
@@ -30,7 +30,7 @@ Click **Create Workspace**. Enter a name, select a location, and click **Create*
 
 ### Step 4
 
-Now you should be looking at your workspace settings. Provide `https://github.com/jpapejr/iks-life-preserver/tree/main` as the Terraform template URL and ensure that you choose a Terraform version of 0.12 or higher for this workspace. Click `Save template information` to save your changes. Wait for the system import and process the Terraform data before continuing.
+Now you should be looking at your workspace settings. Provide `https://github.com/jpapejr/iks-life-preserver/tree/main` as the Terraform template URL and ensure that you choose a Terraform version of 0.12 or higher for this workspace. Click **Save template information** to save your changes. Wait for the system import and process the Terraform data before continuing.
 
 ### Step 5
 
@@ -38,28 +38,28 @@ You should now see four variables that need to be populated before continuing:
 
 * `reference` - This is a user-defined reference that will be appeanded to the generated service ID name for purpose reference.
 * `cluster` - This is the **cluster ID** of the specific cluster to grant **read-only** access to.
-* `apikey` - This is an IBM Cloud API Key with sufficient privileges to invite new members to the account. For security purposes, ensure you check the `Sensitive` box on the far right so your key is obscured from view after it input.
+* `apikey` - This is an IBM Cloud API Key with sufficient privileges to invite new members to the account. For security purposes, ensure you check the **Sensitive** box on the far right so your key is obscured from view after it input.
 * `account` - This is the target account within which the operations will occur. 
 
-When done, click `Save changes`.
+When done, click **Save changes**.
 
 ### Step 6
 
-At the top of the screen click on the `Generate plan` button. Ensure it completes successfully before moving on. Address any Terraform errors that might arise due to back API Key or cluster ID values. 
+At the top of the screen click on the **Generate plan** button. Ensure it completes successfully before moving on. Address any Terraform errors that might arise due to back API Key or cluster ID values. 
 
 ### Step 7
 
-Again, at the top of the screen, click on the `Apply plan` button. Once the `apply` operation has completed, you can click on `View Logs` to find the generated Service ID API Key. Share this securely with the individual providing assistance; they will be able to authenticate using this API Key for the targeted account & cluster resources as defined above. 
+Again, at the top of the screen, click on the **Apply plan** button. Once the **apply** operation has completed, you can click on **View Logs** to find the generated Service ID API Key. Share this securely with the individual providing assistance; they will be able to authenticate using this API Key for the targeted account & cluster resources as defined above. 
 
 ### Step 8
 
-At this point, if the `apply` operation was successful you should be able to browse into the [IAM portion of the console](https://cloud.ibm.com/iam/users) to confirm the access. 
+At this point, if the **apply** operation was successful you should be able to browse into the [IAM portion of the console](https://cloud.ibm.com/iam/users) to confirm the access. 
 
 
 
 ### Step 9 (Revoke access)
 
-From the main workspace page, click on the `Actions` drop-down button near the top-right part of the screen and select `Delete`:
+In the overview for the Schematics workspace, click the **Actions** drop-down list and select **Delete**:
 
 * To remove all changes and delete the workspace completely, select both checkboxes.
 * To remove all changes and keep the workspace for re-use at a later time, select only the second checkbox. 

--- a/iks-life-preserver/README.md
+++ b/iks-life-preserver/README.md
@@ -13,7 +13,7 @@ Follow the steps below to invite a user to your account and grant them:
 * A `Viewer` IAM platform policy that allows the user to see only Kubernetes and OpenShift clusters
 * A `Reader` IAM service policy that allows the user to have **view-only** access to the **specific cluster you grant them access to**. 
 
-> Note: In terms of Kubernetes RBAC, this user will not have access to any Secrets or RBAC resources inside the cluster.
+> Note: These IAM policies do not grant the user access to any Kubernetes secrets or RBAC resources inside the cluster.
 
 
 ### Step 1

--- a/iks-life-preserver/README.md
+++ b/iks-life-preserver/README.md
@@ -61,7 +61,7 @@ At this point, if the `apply` operation was successful you should be able to bro
 
 From the main workspace page, click on the `Actions` drop-down button near the top-right part of the screen and select `Delete`:
 
-* If you want to remove all the changes and delete the workspace completely, check both boxes.
+* To remove all changes and delete the workspace completely, select both checkboxes.
 * If you want to remove all the changes and keep the workspace around for re-use at a later time, just check the second box. 
 
 Confirm the operation by typing in the workspace name and then clicking `Delete`

--- a/iks-life-preserver/README.md
+++ b/iks-life-preserver/README.md
@@ -57,7 +57,7 @@ At this point, if the `apply` operation was successful you should be able to bro
 
 
 
-### Step 9 (roll-back/revert the process)
+### Step 9 (Revoke access)
 
 From the main workspace page, click on the `Actions` drop-down button near the top-right part of the screen and select `Delete`:
 

--- a/iks-life-preserver/README.md
+++ b/iks-life-preserver/README.md
@@ -18,7 +18,7 @@ Follow the steps below to invite a user to your account and grant them:
 
 ### Step 1
 
- Login to the IBM Cloud web console at https://cloud.ibm.com.
+[Log in to your IBM Cloud account.](https://cloud.ibm.com)
 
 ### Step 2 
 

--- a/iks-life-preserver/README.md
+++ b/iks-life-preserver/README.md
@@ -64,4 +64,4 @@ From the main workspace page, click on the `Actions` drop-down button near the t
 * To remove all changes and delete the workspace completely, select both checkboxes.
 * To remove all changes and keep the workspace for re-use at a later time, select only the second checkbox. 
 
-Confirm the operation by typing in the workspace name and then clicking `Delete`
+Confirm the operation by entering the workspace name and clicking **Delete**.

--- a/iks-life-preserver/createKey.sh
+++ b/iks-life-preserver/createKey.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+ibmcloud login -a cloud.ibm.com --apikey $1 -c $2 -r us-south --quiet > /dev/null
+ibmcloud iam service-api-key-create life-preserver life-preserver-id-$3 --output json | jq ". | {id: .id, name: .name, acct: .account_id, apikey: .apikey}"

--- a/iks-life-preserver/main.tf
+++ b/iks-life-preserver/main.tf
@@ -23,14 +23,3 @@ data "external" "apikey" {
 }
 
 
-# resource "ibm_iam_user_policy" "policy" {
-#   depends_on = [ ibm_iam_user_invite.invite_user ]
-#   ibm_id = var.user
-#   roles  = ["Viewer", "Reader"]
-#   tags   = [ "life-preserver" ]
-#   resources {
-#     service              = "containers-kubernetes"
-#     resource_instance_id = var.cluster
-#   }
-# }
-

--- a/iks-life-preserver/main.tf
+++ b/iks-life-preserver/main.tf
@@ -1,0 +1,36 @@
+provider "ibm" {
+  ibmcloud_api_key = var.apikey
+}
+
+resource "ibm_iam_service_id" "lifeperserver" {
+  name = "life-preserver-id-${var.reference}"
+}
+
+resource "ibm_iam_service_policy" "life-preserver-policy" {
+  depends_on = [ ibm_iam_service_id.lifeperserver ]
+  iam_service_id = ibm_iam_service_id.lifeperserver.id
+  roles        = [ "Viewer", "Reader"]
+
+  resources {
+    service              = "containers-kubernetes"
+    resource_instance_id = var.cluster
+  }
+}
+
+data "external" "apikey" {
+  depends_on = [ ibm_iam_service_id.lifeperserver ]
+  program = ["bash", "${path.root}/createKey.sh", var.apikey, var.account, var.reference]
+}
+
+
+# resource "ibm_iam_user_policy" "policy" {
+#   depends_on = [ ibm_iam_user_invite.invite_user ]
+#   ibm_id = var.user
+#   roles  = ["Viewer", "Reader"]
+#   tags   = [ "life-preserver" ]
+#   resources {
+#     service              = "containers-kubernetes"
+#     resource_instance_id = var.cluster
+#   }
+# }
+

--- a/iks-life-preserver/outputs.tf
+++ b/iks-life-preserver/outputs.tf
@@ -1,0 +1,3 @@
+output "apikey" {
+  value = data.external.apikey.result.apikey
+}

--- a/iks-life-preserver/variables.tf
+++ b/iks-life-preserver/variables.tf
@@ -1,0 +1,15 @@
+variable "cluster" { 
+    description = "The cluster ID of the target cluster"
+}
+
+variable "apikey" {
+    description = "An IBM Cloud API Key with permission to invite users to the account"
+}
+
+variable "reference" {
+    description = "A reference tag/string of your choosing (I.e case number, etc.)"
+}
+
+variable "account" {
+    description = "The IBM Cloud account ID to use"
+}

--- a/iks-life-preserver/versions.tf
+++ b/iks-life-preserver/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Internal design doc and background - https://ibm.ent.box.com/notes/729730770506

tl;dr - this PR adds in a convenience Terraform configuration for simplifying the process for securely requesting debug assistance from another person (I.e. an IBM Support rep or developer) for the purposes of debugging an IKS cluster issue. This Terraform content will generate a Service ID and an associated API Key that can be used to authenticate to IBM Cloud via the CLI and only have Viewer/Reader access to a specific IKS cluster in a specific account. The user cannot update in-cluster RBAC or Secrets. To revoke the access, simply delete the IBM Cloud Schematics workspace and associated resources. 