### PR TITLE
calico-policies: enable pod egress to metrics-server

### DIFF
--- a/calico-policies/public-network-isolation/README.md
+++ b/calico-policies/public-network-isolation/README.md
@@ -38,6 +38,7 @@ Along with the default Calico policies that are applied to the public interface 
   * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * TCP/UDP 20000:32767 and 443 for communication with the Kubernetes master
+  * TCP 4443 for metrics-server
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the public network interface for pods is permitted from network load balancer (NLB), Ingress application load balancer (ALB), and NodePort services.
 

--- a/calico-policies/public-network-isolation/au-syd/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-egress-pods-public.yaml
@@ -1,6 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage, 10250 for VPN pod, and
+# for communication to block storage 10250 for VPN pod, port 4443 for
+# communication to metrics-server and 
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -26,6 +27,7 @@ spec:
       - 53
       - 5353
       - 443
+      - 4443
       - 2049
       - 3260
       - 10250

--- a/calico-policies/public-network-isolation/eu-de/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-egress-pods-public.yaml
@@ -1,6 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage, 10250 for VPN pod, and
+# for communication to block storage 10250 for VPN pod, port 4443 for
+# communication to metrics-server and 
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -26,6 +27,7 @@ spec:
       - 53
       - 5353
       - 443
+      - 4443
       - 2049
       - 3260
       - 10250

--- a/calico-policies/public-network-isolation/eu-gb/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-egress-pods-public.yaml
@@ -1,6 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage, 10250 for VPN pod, and
+# for communication to block storage 10250 for VPN pod, port 4443 for
+# communication to metrics-server and 
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -26,6 +27,7 @@ spec:
       - 53
       - 5353
       - 443
+      - 4443
       - 2049
       - 3260
       - 10250

--- a/calico-policies/public-network-isolation/jp-tok/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-egress-pods-public.yaml
@@ -1,6 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage, 10250 for VPN pod, and
+# for communication to block storage 10250 for VPN pod, port 4443 for
+# communication to metrics-server and 
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -26,6 +27,7 @@ spec:
       - 53
       - 5353
       - 443
+      - 4443
       - 2049
       - 3260
       - 10250

--- a/calico-policies/public-network-isolation/us-east/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-egress-pods-public.yaml
@@ -1,6 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage 10250 for VPN pod, and
+# for communication to block storage 10250 for VPN pod, port 4443 for
+# communication to metrics-server and 
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -26,6 +27,7 @@ spec:
       - 53
       - 5353
       - 443
+      - 4443
       - 2049
       - 3260
       - 10250

--- a/calico-policies/public-network-isolation/us-south/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-egress-pods-public.yaml
@@ -1,6 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage 10250 for VPN pod, and
+# for communication to block storage 10250 for VPN pod, port 4443 for
+# communication to metrics-server and 
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -26,6 +27,7 @@ spec:
       - 53
       - 5353
       - 443
+      - 4443
       - 2049
       - 3260
       - 10250


### PR DESCRIPTION
## What

This PR adds the `metrics-server` port `4443` to the allow list of pod egress ports in the public network isolation policy samples.

I haven't made the same change in the private network isolation policies, though it may be required there also.

## Why

After applying the public network isolation policies to our IKS cluster, we found that services using the apiservice `v1beta1.metrics.k8s.io` were failing. 

For example:
 * deleted namespaces were stuck in `Terminating` state with:

        status:
          conditions:
          - lastTransitionTime: "2020-11-13T13:50:40Z"
             message: 'Discovery failed for some groups, 1 failing: unable to retrieve the
                complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently
                unable to handle the request'
             reason: DiscoveryFailed

 * `horizontalpodautoscaler` would raise `FailedGetResourceMetric` events

A simple test that `metrics-server` is reachable is:

`kubectl get --raw /api/v1/namespaces/kube-system/services/https:metrics-server:443/proxy/healthz`

which should return `ok`.