### PR TITLE
added secret type to duplicated secret

### DIFF
--- a/secret-sync-operator/pkg/controller/secret/secret_controller.go
+++ b/secret-sync-operator/pkg/controller/secret/secret_controller.go
@@ -80,6 +80,7 @@ func createSecret(secret *corev1.Secret, name string, namespace string) (*corev1
 			Annotations: annotations,
 		},
 		Data: secret.Data,
+		Type: secret.Type,
 	}, nil
 }
 


### PR DESCRIPTION
Added the secret type to the duplicated secret in secret-sync-operator. Because secret type is immutable, we had to delete the replicated secrets before deploying the updated version. Otherwise, there was an error trying to duplicate a kubernetes.io/tls secret to a previously created Opaque secret.