### PR TITLE
removing egress 443 from private samples

### DIFF
--- a/calico-policies/private-network-isolation/README.md
+++ b/calico-policies/private-network-isolation/README.md
@@ -16,7 +16,7 @@ The Calico policies are organized by region. Choose the directory for the region
 * Egress network traffic on the private network interface for worker nodes is permitted to the following ports:
   * TCP/UDP 53 and 5353 for OpenShift version 4.3 or later for DNS
   * TCP/UDP 2049 for communication with NFS file servers
-  * TCP/UDP 443 and 3260 for communication to block storage
+  * TCP/UDP 3260 for communication to block storage
   * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * Specified ports for other IBM Cloud services
@@ -31,7 +31,7 @@ The Calico policies are organized by region. Choose the directory for the region
 * Egress network traffic on the private network interface for pods to private networks is denied. If worker nodes are connected to a public VLAN, pod egress is permitted to public networks. All other pod egress on the private network interface is permitted to the following ports:
   * TCP/UDP 53 and 5353 for OpenShift version 4.3 or later for DNS
   * TCP/UDP 2049 for communication with NFS file servers
-  * TCP/UDP 443 and 3260 for communication to block storage
+  * TCP/UDP 3260 for communication to block storage
   * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * TCP/UDP 20000:32767 and 443 for communication with the Kubernetes master

--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-ibm-ports-private.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 2040 and 2041 on
+# port 3260 for communication to block storage, port 2040 and 2041 on
 # 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
 # (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
 
@@ -16,7 +16,6 @@ spec:
       ports:
       - 53
       - 5353
-      - 443
       - 2049
       - 3260
     protocol: UDP
@@ -26,7 +25,6 @@ spec:
       ports:
       - 53
       - 5353
-      - 443
       - 2049
       - 3260
     protocol: TCP

--- a/calico-policies/private-network-isolation/calico-v3/eu-de/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-de/allow-ibm-ports-private.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 2040 and 2041 on
+# port 3260 for communication to block storage, port 2040 and 2041 on
 # 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
 # (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
 
@@ -16,7 +16,6 @@ spec:
       ports:
       - 53
       - 5353
-      - 443
       - 2049
       - 3260
     protocol: UDP
@@ -26,7 +25,6 @@ spec:
       ports:
       - 53
       - 5353
-      - 443
       - 2049
       - 3260
     protocol: TCP

--- a/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-ibm-ports-private.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 2040 and 2041 on
+# ports 3260 for communication to block storage, port 2040 and 2041 on
 # 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
 # (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
 
@@ -16,7 +16,6 @@ spec:
       ports:
       - 53
       - 5353
-      - 443
       - 2049
       - 3260
     protocol: UDP
@@ -26,7 +25,6 @@ spec:
       ports:
       - 53
       - 5353
-      - 443
       - 2049
       - 3260
     protocol: TCP

--- a/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-ibm-ports-private.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 2040 and 2041 on
+# port 3260 for communication to block storage, port 2040 and 2041 on
 # 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
 # (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
 
@@ -16,7 +16,6 @@ spec:
       ports:
       - 53
       - 5353
-      - 443
       - 2049
       - 3260
     protocol: UDP
@@ -26,7 +25,6 @@ spec:
       ports:
       - 53
       - 5353
-      - 443
       - 2049
       - 3260
     protocol: TCP

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-ibm-ports-private.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 2040 and 2041 on
+# ports 3260 for communication to block storage, port 2040 and 2041 on
 # 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
 # (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
 
@@ -16,7 +16,6 @@ spec:
       ports:
       - 53
       - 5353
-      - 443
       - 2049
       - 3260
     protocol: UDP
@@ -26,7 +25,6 @@ spec:
       ports:
       - 53
       - 5353
-      - 443
       - 2049
       - 3260
     protocol: TCP

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-ibm-ports-private.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# ports 443 and 3260 for communication to block storage, port 2040 and 2041 on
+# port 3260 for communication to block storage, port 2040 and 2041 on
 # 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
 # (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
 
@@ -16,7 +16,6 @@ spec:
       ports:
       - 53
       - 5353
-      - 443
       - 2049
       - 3260
     protocol: UDP
@@ -26,7 +25,6 @@ spec:
       ports:
       - 53
       - 5353
-      - 443
       - 2049
       - 3260
     protocol: TCP


### PR DESCRIPTION
Based on a discussion with storage team there is no need to include port 443 in egress policies since it is not required by block-storage.