### PR TITLE
Add calico-typha port for clusters using Calico KDD

### DIFF
--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-ibm-ports-private.yaml
@@ -1,9 +1,10 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# port 3260 for communication to block storage, port 2040 and 2041 on
-# 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
-# (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
+# port 3260 for communication to block storage, port 5473 for communication to
+# the calico-typha ClusterIP, port 2040 and 2041 on 172.20.0.0/24 for the master
+# API server local proxy, and port 443 on 172.21.0.1 (or 10.10.10.1 for clusters
+# created more than 2 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -18,6 +19,7 @@ spec:
       - 5353
       - 2049
       - 3260
+      - 5473
     protocol: UDP
     source: {}
   - action: Allow
@@ -27,6 +29,7 @@ spec:
       - 5353
       - 2049
       - 3260
+      - 5473
     protocol: TCP
     source: {}
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/eu-de/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-de/allow-ibm-ports-private.yaml
@@ -1,9 +1,10 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# port 3260 for communication to block storage, port 2040 and 2041 on
-# 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
-# (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
+# port 3260 for communication to block storage, port 5473 for communication to
+# the calico-typha ClusterIP, port 2040 and 2041 on 172.20.0.0/24 for the master
+# API server local proxy, and port 443 on 172.21.0.1 (or 10.10.10.1 for clusters
+# created more than 2 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -18,6 +19,7 @@ spec:
       - 5353
       - 2049
       - 3260
+      - 5473
     protocol: UDP
     source: {}
   - action: Allow
@@ -27,6 +29,7 @@ spec:
       - 5353
       - 2049
       - 3260
+      - 5473
     protocol: TCP
     source: {}
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-ibm-ports-private.yaml
@@ -1,9 +1,10 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# ports 3260 for communication to block storage, port 2040 and 2041 on
-# 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
-# (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
+# port 3260 for communication to block storage, port 5473 for communication to
+# the calico-typha ClusterIP, port 2040 and 2041 on 172.20.0.0/24 for the master
+# API server local proxy, and port 443 on 172.21.0.1 (or 10.10.10.1 for clusters
+# created more than 2 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -18,6 +19,7 @@ spec:
       - 5353
       - 2049
       - 3260
+      - 5473
     protocol: UDP
     source: {}
   - action: Allow
@@ -27,6 +29,7 @@ spec:
       - 5353
       - 2049
       - 3260
+      - 5473
     protocol: TCP
     source: {}
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-ibm-ports-private.yaml
@@ -1,9 +1,10 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# port 3260 for communication to block storage, port 2040 and 2041 on
-# 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
-# (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
+# port 3260 for communication to block storage, port 5473 for communication to
+# the calico-typha ClusterIP, port 2040 and 2041 on 172.20.0.0/24 for the master
+# API server local proxy, and port 443 on 172.21.0.1 (or 10.10.10.1 for clusters
+# created more than 2 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -18,6 +19,7 @@ spec:
       - 5353
       - 2049
       - 3260
+      - 5473
     protocol: UDP
     source: {}
   - action: Allow
@@ -27,6 +29,7 @@ spec:
       - 5353
       - 2049
       - 3260
+      - 5473
     protocol: TCP
     source: {}
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-ibm-ports-private.yaml
@@ -1,9 +1,10 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# ports 3260 for communication to block storage, port 2040 and 2041 on
-# 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
-# (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
+# port 3260 for communication to block storage, port 5473 for communication to
+# the calico-typha ClusterIP, port 2040 and 2041 on 172.20.0.0/24 for the master
+# API server local proxy, and port 443 on 172.21.0.1 (or 10.10.10.1 for clusters
+# created more than 2 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -18,6 +19,7 @@ spec:
       - 5353
       - 2049
       - 3260
+      - 5473
     protocol: UDP
     source: {}
   - action: Allow
@@ -27,6 +29,7 @@ spec:
       - 5353
       - 2049
       - 3260
+      - 5473
     protocol: TCP
     source: {}
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-ibm-ports-private.yaml
@@ -1,9 +1,10 @@
 # This policy opens port 10250 for VPN communication between master and workers,
 # port 53 for DNS (5353 for OpenShift 4.3 and later), port 52311 for IBM BigFix
 # worker node updates, port 2049 forcommunication with NFS file servers,
-# port 3260 for communication to block storage, port 2040 and 2041 on
-# 172.20.0.0/24 for the master API server local proxy, and port 443 on 172.21.0.1
-# (or 10.10.10.1 for clusters created more than 2 years ago) for the etcd local proxy.
+# port 3260 for communication to block storage, port 5473 for communication to
+# the calico-typha ClusterIP, port 2040 and 2041 on 172.20.0.0/24 for the master
+# API server local proxy, and port 443 on 172.21.0.1 (or 10.10.10.1 for clusters
+# created more than 2 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -18,6 +19,7 @@ spec:
       - 5353
       - 2049
       - 3260
+      - 5473
     protocol: UDP
     source: {}
   - action: Allow
@@ -27,6 +29,7 @@ spec:
       - 5353
       - 2049
       - 3260
+      - 5473
     protocol: TCP
     source: {}
   - action: Allow

--- a/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
@@ -1,7 +1,9 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
-# for communication to block storage, port 2040 and 443 for the master
+# for communication to block storage, port 5473 for communication to the
+# calico-typha ClusterIP, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.
+# Port 52311 for Bigfix.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -17,6 +19,7 @@ spec:
       - 443
       - 2049
       - 3260
+      - 5473
     protocol: UDP
     source: {}
   - action: Allow
@@ -27,6 +30,7 @@ spec:
       - 443
       - 2049
       - 3260
+      - 5473
     protocol: TCP
     source: {}
   - action: Allow

--- a/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
@@ -1,7 +1,9 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
-# for communication to block storage, port 2040 and 443 for the master
+# for communication to block storage, port 5473 for communication to the
+# calico-typha ClusterIP, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.
+# Port 52311 for Bigfix.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -17,6 +19,7 @@ spec:
       - 443
       - 2049
       - 3260
+      - 5473
     protocol: UDP
     source: {}
   - action: Allow
@@ -27,6 +30,7 @@ spec:
       - 443
       - 2049
       - 3260
+      - 5473
     protocol: TCP
     source: {}
   - action: Allow

--- a/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
@@ -1,7 +1,9 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
-# for communication to block storage, port 2040 and 443 for the master
+# for communication to block storage, port 5473 for communication to the
+# calico-typha ClusterIP, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.
+# Port 52311 for Bigfix.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -17,6 +19,7 @@ spec:
       - 443
       - 2049
       - 3260
+      - 5473
     protocol: UDP
     source: {}
   - action: Allow
@@ -27,6 +30,7 @@ spec:
       - 443
       - 2049
       - 3260
+      - 5473
     protocol: TCP
     source: {}
   - action: Allow

--- a/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
@@ -1,7 +1,9 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
-# for communication to block storage, port 2040 and 443 for the master
+# for communication to block storage, port 5473 for communication to the
+# calico-typha ClusterIP, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.
+# Port 52311 for Bigfix.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -17,6 +19,7 @@ spec:
       - 443
       - 2049
       - 3260
+      - 5473
     protocol: UDP
     source: {}
   - action: Allow
@@ -27,6 +30,7 @@ spec:
       - 443
       - 2049
       - 3260
+      - 5473
     protocol: TCP
     source: {}
   - action: Allow

--- a/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
@@ -1,7 +1,9 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
-# for communication to block storage, port 2040 and 443 for the master
+# for communication to block storage, port 5473 for communication to the
+# calico-typha ClusterIP, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.
+# Port 52311 for Bigfix.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -17,6 +19,7 @@ spec:
       - 443
       - 2049
       - 3260
+      - 5473
     protocol: UDP
     source: {}
   - action: Allow
@@ -27,6 +30,7 @@ spec:
       - 443
       - 2049
       - 3260
+      - 5473
     protocol: TCP
     source: {}
   - action: Allow

--- a/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
@@ -1,7 +1,9 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers, ports 443 and 3260,
-# for communication to block storage, port 2040 and 443 for the master
+# for communication to block storage, port 5473 for communication to the
+# calico-typha ClusterIP, port 2040 and 443 for the master
 # API server local proxy, and port 2041 for the etcd local proxy.
+# Port 52311 for Bigfix.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -17,6 +19,7 @@ spec:
       - 443
       - 2049
       - 3260
+      - 5473
     protocol: UDP
     source: {}
   - action: Allow
@@ -27,6 +30,7 @@ spec:
       - 443
       - 2049
       - 3260
+      - 5473
     protocol: TCP
     source: {}
   - action: Allow


### PR DESCRIPTION
For clusters that are using Calico KDD mode, we need to allow the typha ClusterIP port.
This includes all VPC clusters, all ROKS clusters, and all IKS Classic clusters with
masters at 1.19 and newer (since classic clusters are migrated to KDD when they are
updated to 1.19).