### PR TITLE
Calico updates

### DIFF
--- a/calico-policies/private-network-isolation/README.md
+++ b/calico-policies/private-network-isolation/README.md
@@ -35,6 +35,7 @@ The Calico policies are organized by region. Choose the directory for the region
   * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * TCP/UDP 20000:32767 and 443 for communication with the Kubernetes master
+  * TCP 4443 for metrics-server for Kubernetes version 1.19 or later, or TCP 6443 for OpenShift version 4.3 or later
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the private network interface for pods is permitted from workers in the cluster.
 

--- a/calico-policies/private-network-isolation/README.md
+++ b/calico-policies/private-network-isolation/README.md
@@ -17,7 +17,7 @@ The Calico policies are organized by region. Choose the directory for the region
   * TCP/UDP 53 and 5353 for OpenShift version 4.3 or later for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 3260 for communication to block storage
-  * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
+  * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 3 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the private network interface for worker nodes is permitted only from subnets for IBM Cloud Infrastructure to manage worker nodes through the following ports:
@@ -32,14 +32,14 @@ The Calico policies are organized by region. Choose the directory for the region
   * TCP/UDP 53 and 5353 for OpenShift version 4.3 or later for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 3260 for communication to block storage
-  * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
+  * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 3 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * TCP/UDP 20000:32767 and 443 for communication with the Kubernetes master
   * TCP 4443 for metrics-server for Kubernetes version 1.19 or later, or TCP 6443 for OpenShift version 4.3 or later
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the private network interface for pods is permitted from workers in the cluster.
 
-> **IMPORTANT**: When you apply the egress pod policies that are included in this policy set, only network traffic to the subnets and ports that are specified in the pod policies is permitted. All traffic to any subnets or ports that are not specified in the policies is blocked for all pods in all namespaces. Because only the ports and subnets that are necessary for the pods to function in IBM Cloud Kubernetes Service are specified in these policies, your pods cannot send network traffic over the private network until you add or change the Calico policy to allow them to.
+> **IMPORTANT**: When you apply the egress pod policies that are included in this policy set, only network traffic to the subnets and ports that are specified in the pod policies is permitted. All traffic to any subnets or ports that are not specified in the policies is blocked for all pods in all namespaces. Because only the ports and subnets that are necessary for the pods to function in IBM Cloud Kubernetes Service are specified in these policies, your pods cannot send network traffic over the private network until you add or change the Calico policy to allow them to. For example, if you use any in-cluster webhooks, you must add policies to ensure that the webhooks can make the required connections. You also must create policies for any non-local services that extend the Kubernetes API. You can find these services by running `kubectl get apiservices`. For OpenShift clusters, `default/openshift-apiserver` is included as a local service and does not require a network policy.
 
 ## List of Calico policies
 

--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-all-workers-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-all-workers-private.yaml
@@ -13,7 +13,8 @@ spec:
   - action: Allow
     destination:
       nets:
-      # Allows communication to pod IPs
+      # Allows communication to pod IP addresses. If you specified a custom subnet when you created
+      # the cluster that provides the private IP addresses for your pods, use that CIDR instead.
       - 172.30.0.0/16
     source: {}
   ingress:

--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-egress-pods-private.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers,
 # ports 443 and 3260 for communication to block storage,
-# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 10250 for the openVPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.

--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-egress-pods-private.yaml
@@ -1,7 +1,8 @@
 # This policy opens port 53 and 5353 for DNS,
-# port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage, port 10250 for VPN communication,
-# and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also
+# port 2049 for communication with NFS file servers,
+# ports 443 and 3260 for communication to block storage,
+# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.
 
@@ -28,6 +29,8 @@ spec:
       - 53
       - 5353
       - 443
+      - 4443 # Kubernetes 1.19 or later
+      - 6443 # OpenShift 4.3 or later
       - 2049
       - 3260
       - 10250

--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-ibm-ports-private.yaml
@@ -4,7 +4,7 @@
 # port 3260 for communication to block storage, port 5473 for communication to
 # the calico-typha ClusterIP, port 2040 and 2041 on 172.20.0.0/24 for the master
 # API server local proxy, and port 443 on 172.21.0.1 (or 10.10.10.1 for clusters
-# created more than 2 years ago) for the etcd local proxy.
+# created more than 3 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -51,16 +51,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: TCP
   ingress:
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/eu-de/allow-all-workers-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-de/allow-all-workers-private.yaml
@@ -13,7 +13,8 @@ spec:
   - action: Allow
     destination:
       nets:
-      # Allows communication to pod IPs
+      # Allows communication to pod IP addresses. If you specified a custom subnet when you created
+      # the cluster that provides the private IP addresses for your pods, use that CIDR instead.
       - 172.30.0.0/16
     source: {}
   ingress:

--- a/calico-policies/private-network-isolation/calico-v3/eu-de/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-de/allow-egress-pods-private.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers,
 # ports 443 and 3260 for communication to block storage,
-# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 10250 for the openVPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.

--- a/calico-policies/private-network-isolation/calico-v3/eu-de/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-de/allow-egress-pods-private.yaml
@@ -1,7 +1,8 @@
 # This policy opens port 53 and 5353 for DNS,
-# port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage, port 10250 for VPN communication,
-# and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also
+# port 2049 for communication with NFS file servers,
+# ports 443 and 3260 for communication to block storage,
+# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.
 
@@ -28,6 +29,8 @@ spec:
       - 53
       - 5353
       - 443
+      - 4443 # Kubernetes 1.19 or later
+      - 6443 # OpenShift 4.3 or later
       - 2049
       - 3260
       - 10250

--- a/calico-policies/private-network-isolation/calico-v3/eu-de/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-de/allow-ibm-ports-private.yaml
@@ -4,7 +4,7 @@
 # port 3260 for communication to block storage, port 5473 for communication to
 # the calico-typha ClusterIP, port 2040 and 2041 on 172.20.0.0/24 for the master
 # API server local proxy, and port 443 on 172.21.0.1 (or 10.10.10.1 for clusters
-# created more than 2 years ago) for the etcd local proxy.
+# created more than 3 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -51,16 +51,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: TCP
   ingress:
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-all-workers-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-all-workers-private.yaml
@@ -13,7 +13,8 @@ spec:
   - action: Allow
     destination:
       nets:
-      # Allows communication to pod IPs
+      # Allows communication to pod IP addresses. If you specified a custom subnet when you created
+      # the cluster that provides the private IP addresses for your pods, use that CIDR instead.
       - 172.30.0.0/16
     source: {}
   ingress:

--- a/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-egress-pods-private.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers,
 # ports 443 and 3260 for communication to block storage,
-# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 10250 for the openVPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.

--- a/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-egress-pods-private.yaml
@@ -1,7 +1,8 @@
 # This policy opens port 53 and 5353 for DNS,
-# port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage, port 10250 for VPN communication,
-# and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also
+# port 2049 for communication with NFS file servers,
+# ports 443 and 3260 for communication to block storage,
+# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.
 
@@ -28,6 +29,8 @@ spec:
       - 53
       - 5353
       - 443
+      - 4443 # Kubernetes 1.19 or later
+      - 6443 # OpenShift 4.3 or later
       - 2049
       - 3260
       - 10250

--- a/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/eu-gb/allow-ibm-ports-private.yaml
@@ -4,7 +4,7 @@
 # port 3260 for communication to block storage, port 5473 for communication to
 # the calico-typha ClusterIP, port 2040 and 2041 on 172.20.0.0/24 for the master
 # API server local proxy, and port 443 on 172.21.0.1 (or 10.10.10.1 for clusters
-# created more than 2 years ago) for the etcd local proxy.
+# created more than 3 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -51,16 +51,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: TCP
   ingress:
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-all-workers-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-all-workers-private.yaml
@@ -13,7 +13,8 @@ spec:
   - action: Allow
     destination:
       nets:
-      # Allows communication to pod IPs
+      # Allows communication to pod IP addresses. If you specified a custom subnet when you created
+      # the cluster that provides the private IP addresses for your pods, use that CIDR instead.
       - 172.30.0.0/16
     source: {}
   ingress:

--- a/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-egress-pods-private.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers,
 # ports 443 and 3260 for communication to block storage,
-# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 10250 for the openVPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.

--- a/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-egress-pods-private.yaml
@@ -1,7 +1,8 @@
 # This policy opens port 53 and 5353 for DNS,
-# port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage, port 10250 for VPN communication,
-# and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also
+# port 2049 for communication with NFS file servers,
+# ports 443 and 3260 for communication to block storage,
+# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.
 
@@ -28,6 +29,8 @@ spec:
       - 53
       - 5353
       - 443
+      - 4443 # Kubernetes 1.19 or later
+      - 6443 # OpenShift 4.3 or later
       - 2049
       - 3260
       - 10250

--- a/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/jp-tok/allow-ibm-ports-private.yaml
@@ -4,7 +4,7 @@
 # port 3260 for communication to block storage, port 5473 for communication to
 # the calico-typha ClusterIP, port 2040 and 2041 on 172.20.0.0/24 for the master
 # API server local proxy, and port 443 on 172.21.0.1 (or 10.10.10.1 for clusters
-# created more than 2 years ago) for the etcd local proxy.
+# created more than 3 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -51,16 +51,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: TCP
   ingress:
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-all-workers-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-all-workers-private.yaml
@@ -13,7 +13,8 @@ spec:
   - action: Allow
     destination:
       nets:
-      # Allows communication to pod IPs
+      # Allows communication to pod IP addresses. If you specified a custom subnet when you created
+      # the cluster that provides the private IP addresses for your pods, use that CIDR instead.
       - 172.30.0.0/16
     source: {}
   ingress:

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-egress-pods-private.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers,
 # ports 443 and 3260 for communication to block storage,
-# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 10250 for the openVPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-egress-pods-private.yaml
@@ -1,7 +1,8 @@
 # This policy opens port 53 and 5353 for DNS,
-# port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage, port 10250 for VPN communication,
-# and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also
+# port 2049 for communication with NFS file servers,
+# ports 443 and 3260 for communication to block storage,
+# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.
 
@@ -28,6 +29,8 @@ spec:
       - 53
       - 5353
       - 443
+      - 4443 # Kubernetes 1.19 or later
+      - 6443 # OpenShift 4.3 or later
       - 2049
       - 3260
       - 10250

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-ibm-ports-private.yaml
@@ -4,7 +4,7 @@
 # port 3260 for communication to block storage, port 5473 for communication to
 # the calico-typha ClusterIP, port 2040 and 2041 on 172.20.0.0/24 for the master
 # API server local proxy, and port 443 on 172.21.0.1 (or 10.10.10.1 for clusters
-# created more than 2 years ago) for the etcd local proxy.
+# created more than 3 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -51,16 +51,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: TCP
   ingress:
   - action: Allow

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-all-workers-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-all-workers-private.yaml
@@ -13,7 +13,8 @@ spec:
   - action: Allow
     destination:
       nets:
-      # Allows communication to pod IPs
+      # Allows communication to pod IP addresses. If you specified a custom subnet when you created
+      # the cluster that provides the private IP addresses for your pods, use that CIDR instead.
       - 172.30.0.0/16
     source: {}
   ingress:

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-egress-pods-private.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers,
 # ports 443 and 3260 for communication to block storage,
-# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 10250 for the openVPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-egress-pods-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-egress-pods-private.yaml
@@ -1,7 +1,8 @@
 # This policy opens port 53 and 5353 for DNS,
-# port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage, port 10250 for VPN communication,
-# and port 2040 and 2041 on 172.20.0.0 for the master API server local proxy. It also
+# port 2049 for communication with NFS file servers,
+# ports 443 and 3260 for communication to block storage,
+# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy. It also
 # allows pod access to other pods, denies access to private networks but allows access to
 # public networks, and allows access in each zone of the region to the master.
 
@@ -28,6 +29,8 @@ spec:
       - 53
       - 5353
       - 443
+      - 4443 # Kubernetes 1.19 or later
+      - 6443 # OpenShift 4.3 or later
       - 2049
       - 3260
       - 10250

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-ibm-ports-private.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-ibm-ports-private.yaml
@@ -4,7 +4,7 @@
 # port 3260 for communication to block storage, port 5473 for communication to
 # the calico-typha ClusterIP, port 2040 and 2041 on 172.20.0.0/24 for the master
 # API server local proxy, and port 443 on 172.21.0.1 (or 10.10.10.1 for clusters
-# created more than 2 years ago) for the etcd local proxy.
+# created more than 3 years ago) for the etcd local proxy.
 
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
@@ -51,16 +51,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: TCP
   ingress:
   - action: Allow

--- a/calico-policies/public-network-isolation/README.md
+++ b/calico-policies/public-network-isolation/README.md
@@ -20,7 +20,7 @@ Along with the default Calico policies that are applied to the public interface 
   * TCP/UDP 53 and 5353 for OpenShift version 4.3 or later for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
-  * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
+  * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 3 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the public network interface for worker nodes is permitted only from subnets for IBM Cloud infrastructure to manage worker nodes through the following ports:
@@ -35,14 +35,14 @@ Along with the default Calico policies that are applied to the public interface 
   * TCP/UDP 53 and 5353 for OpenShift version 4.3 or later for DNS
   * TCP/UDP 2049 for communication with NFS file servers
   * TCP/UDP 443 and 3260 for communication to block storage
-  * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
+  * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 3 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * TCP/UDP 20000:32767 and 443 for communication with the Kubernetes master
   * TCP 4443 for metrics-server for Kubernetes version 1.19 or later, or TCP 6443 for OpenShift version 4.3 or later
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the public network interface for pods is permitted from network load balancer (NLB), Ingress application load balancer (ALB), and NodePort services.
 
-> **IMPORTANT**: When you apply the egress pod policies that are included in this policy set, only network traffic to the subnets and ports that are specified in the pod policies is permitted. All traffic to any subnets or ports that are not specified in the policies is blocked for all pods in all namespaces. Because only the ports and subnets that are necessary for the pods to function in IBM Cloud Kubernetes Service are specified in these policies, your pods cannot send network traffic over the internet until you add or change the Calico policy to allow them to.
+> **IMPORTANT**: When you apply the egress pod policies that are included in this policy set, only network traffic to the subnets and ports that are specified in the pod policies is permitted. All traffic to any subnets or ports that are not specified in the policies is blocked for all pods in all namespaces. Because only the ports and subnets that are necessary for the pods to function in IBM Cloud Kubernetes Service are specified in these policies, your pods cannot send network traffic over the private network until you add or change the Calico policy to allow them to. For example, if you use any in-cluster webhooks, you must add policies to ensure that the webhooks can make the required connections. You also must create policies for any non-local services that extend the Kubernetes API. You can find these services by running `kubectl get apiservices`. For OpenShift clusters, `default/openshift-apiserver` is included as a local service and does not require a network policy.
 
 ## List of Calico policies
 

--- a/calico-policies/public-network-isolation/README.md
+++ b/calico-policies/public-network-isolation/README.md
@@ -38,7 +38,7 @@ Along with the default Calico policies that are applied to the public interface 
   * TCP/UDP 443 on 172.21.0.1 (or 10.10.10.1 for clusters created more than 2 years ago) for the Kubernetes master API server local proxy
   * TCP/UDP 2040 and 2041 on 172.20.0.0 for the etcd local proxy
   * TCP/UDP 20000:32767 and 443 for communication with the Kubernetes master
-  * TCP 4443 for metrics-server
+  * TCP 4443 for metrics-server for Kubernetes version 1.19 or later, or TCP 6443 for OpenShift version 4.3 or later
   * Specified ports for other IBM Cloud services
 * Ingress network traffic on the public network interface for pods is permitted from network load balancer (NLB), Ingress application load balancer (ALB), and NodePort services.
 

--- a/calico-policies/public-network-isolation/au-syd/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
-# port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage 10250 for VPN pod, port 4443 for
-# communication to metrics-server and 
+# port 2049 for communication with NFS file servers,
+# ports 443 and 3260 for communication to block storage,
+# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -27,7 +27,8 @@ spec:
       - 53
       - 5353
       - 443
-      - 4443
+      - 4443 # Kubernetes 1.19 or later
+      - 6443 # OpenShift 4.3 or later
       - 2049
       - 3260
       - 10250

--- a/calico-policies/public-network-isolation/au-syd/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers,
 # ports 443 and 3260 for communication to block storage,
-# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 10250 for the openVPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3

--- a/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
@@ -38,16 +38,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: TCP
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/eu-de/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
-# port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage 10250 for VPN pod, port 4443 for
-# communication to metrics-server and 
+# port 2049 for communication with NFS file servers,
+# ports 443 and 3260 for communication to block storage,
+# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -27,7 +27,8 @@ spec:
       - 53
       - 5353
       - 443
-      - 4443
+      - 4443 # Kubernetes 1.19 or later
+      - 6443 # OpenShift 4.3 or later
       - 2049
       - 3260
       - 10250

--- a/calico-policies/public-network-isolation/eu-de/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers,
 # ports 443 and 3260 for communication to block storage,
-# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 10250 for the openVPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3

--- a/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
@@ -38,16 +38,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: TCP
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/eu-gb/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
-# port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage 10250 for VPN pod, port 4443 for
-# communication to metrics-server and 
+# port 2049 for communication with NFS file servers,
+# ports 443 and 3260 for communication to block storage,
+# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -27,7 +27,8 @@ spec:
       - 53
       - 5353
       - 443
-      - 4443
+      - 4443 # Kubernetes 1.19 or later
+      - 6443 # OpenShift 4.3 or later
       - 2049
       - 3260
       - 10250

--- a/calico-policies/public-network-isolation/eu-gb/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers,
 # ports 443 and 3260 for communication to block storage,
-# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 10250 for the openVPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3

--- a/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
@@ -38,16 +38,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: TCP
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/jp-tok/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
-# port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage 10250 for VPN pod, port 4443 for
-# communication to metrics-server and 
+# port 2049 for communication with NFS file servers,
+# ports 443 and 3260 for communication to block storage,
+# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -27,7 +27,8 @@ spec:
       - 53
       - 5353
       - 443
-      - 4443
+      - 4443 # Kubernetes 1.19 or later
+      - 6443 # OpenShift 4.3 or later
       - 2049
       - 3260
       - 10250

--- a/calico-policies/public-network-isolation/jp-tok/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers,
 # ports 443 and 3260 for communication to block storage,
-# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 10250 for the openVPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3

--- a/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
@@ -38,16 +38,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: TCP
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/us-east/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
-# port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage 10250 for VPN pod, port 4443 for
-# communication to metrics-server and 
+# port 2049 for communication with NFS file servers,
+# ports 443 and 3260 for communication to block storage,
+# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -27,7 +27,8 @@ spec:
       - 53
       - 5353
       - 443
-      - 4443
+      - 4443 # Kubernetes 1.19 or later
+      - 6443 # OpenShift 4.3 or later
       - 2049
       - 3260
       - 10250

--- a/calico-policies/public-network-isolation/us-east/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers,
 # ports 443 and 3260 for communication to block storage,
-# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 10250 for the openVPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3

--- a/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
@@ -38,16 +38,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: TCP
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/us-south/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
-# port 2049 for communication with NFS file servers, ports 443 and 3260
-# for communication to block storage 10250 for VPN pod, port 4443 for
-# communication to metrics-server and 
+# port 2049 for communication with NFS file servers,
+# ports 443 and 3260 for communication to block storage,
+# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3
@@ -27,7 +27,8 @@ spec:
       - 53
       - 5353
       - 443
-      - 4443
+      - 4443 # Kubernetes 1.19 or later
+      - 6443 # OpenShift 4.3 or later
       - 2049
       - 3260
       - 10250

--- a/calico-policies/public-network-isolation/us-south/allow-egress-pods-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-egress-pods-public.yaml
@@ -1,7 +1,7 @@
 # This policy opens port 53 and 5353 for DNS,
 # port 2049 for communication with NFS file servers,
 # ports 443 and 3260 for communication to block storage,
-# port 10250 for VPN pod, port 4443 or 6443 for metrics-server, and
+# port 10250 for the openVPN pod, port 4443 or 6443 for metrics-server, and
 # port 2040 and 2041 on 172.21.0.0/24 for the master API server local proxy.
 
 apiVersion: projectcalico.org/v3

--- a/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
@@ -38,16 +38,16 @@ spec:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: UDP
   - action: Allow
     destination:
       ports:
       - 443
       nets:
-      - 172.21.0.1/32 # For clusters created <2 years ago
-      - 10.10.10.1/32 # For clusters created >2 years ago
+      - 172.21.0.1/32 # For clusters created <3 years ago
+      - 10.10.10.1/32 # For clusters created >3 years ago
     protocol: TCP
   - action: Allow
     destination:


### PR DESCRIPTION
6443 for metrics-server in openshift 4
Note for custom pod subnets
2 years -> 3 years
Webhooks and non-local api extensions require extra policies