### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, these
+# owners will be requested for review when someone opens a
+# pull request.
+* @ghost # ghost just means "no users"
+
+# calico-policies owners
+/calico-policies/ @Rachael-Graham @bradbehle @artberger @Tamas-Biro1
+


### PR DESCRIPTION
Add CODEOWNERS file and add owners for calico-policies.  This is
needed so we can require approvals for these policy changes before
merging.