### PR TITLE
Need to add a rule to public policies for pod cidr

### DIFF
--- a/calico-policies/private-network-isolation/README.md
+++ b/calico-policies/private-network-isolation/README.md
@@ -12,6 +12,10 @@ The Calico policies are organized by region. Choose the directory for the region
 
 > NOTE: The policies in the ca-tor directory are meant for use with the Toronto multizone location. For the Toronto single zone location, use the policies in the us-east directory instead.
 
+## Deployment Notes
+
+If your cluster uses a custom pod subnet (something other than 172.30.0.0/16), including if the cluster is a VPC cluster (which doesn't use the standard pod subnet by default), then before applying the policies, change the instances of 172.30.0.0/16 in these policies to the pod subnet for this cluster
+
 ## Summary of changes made by the Calico policies
 
 **Worker nodes**

--- a/calico-policies/private-network-isolation/README.md
+++ b/calico-policies/private-network-isolation/README.md
@@ -14,7 +14,7 @@ The Calico policies are organized by region. Choose the directory for the region
 
 ## Deployment Notes
 
-If your cluster uses a custom pod subnet (something other than 172.30.0.0/16), including if the cluster is a VPC cluster (which doesn't use the standard pod subnet by default), then before applying the policies, change the instances of 172.30.0.0/16 in these policies to the pod subnet for this cluster
+These policies specify worker node egress to `172.30.0.0/16` as the default pod subnet. If you specified a custom pod subnet when you created a classic cluster, or if you use a VPC cluster (which doesn't use the standard pod subnet by default), you must edit the `allow-all-workers-private.yaml` policy to change `172.30.0.0/16` to the pod subnet CIDR for this cluster instead. To find your cluster's pod subnet, run `ibmcloud ks cluster get -c <cluster_name_or_ID>`.
 
 ## Summary of changes made by the Calico policies
 

--- a/calico-policies/public-network-isolation/README.md
+++ b/calico-policies/public-network-isolation/README.md
@@ -14,7 +14,7 @@ The Calico policies are organized by region. Choose the directory for the region
 
 ## Deployment Notes
 
-If your cluster uses a custom pod subnet (something other than 172.30.0.0/16), including if the cluster is a VPC cluster (which doesn't use the standard pod subnet by default), then before applying the policies, change the instances of 172.30.0.0/16 in these policies to the pod subnet for this cluster
+These policies specify worker node egress to `172.30.0.0/16` as the default pod subnet. If you specified a custom pod subnet when you created a classic cluster, or if you use a VPC cluster (which doesn't use the standard pod subnet by default), you must edit the `allow-ibm-ports-public.yaml` policy to change `172.30.0.0/16` to the pod subnet CIDR for this cluster instead. To find your cluster's pod subnet, run `ibmcloud ks cluster get -c <cluster_name_or_ID>`.
 
 ## Summary of changes made by the Calico policies
 

--- a/calico-policies/public-network-isolation/README.md
+++ b/calico-policies/public-network-isolation/README.md
@@ -12,6 +12,10 @@ The Calico policies are organized by region. Choose the directory for the region
 
 > NOTE: The policies in the ca-tor directory are meant for use with the Toronto multizone location. For the Toronto single zone location, use the policies in the us-east directory instead.
 
+## Deployment Notes
+
+If your cluster uses a custom pod subnet (something other than 172.30.0.0/16), including if the cluster is a VPC cluster (which doesn't use the standard pod subnet by default), then before applying the policies, change the instances of 172.30.0.0/16 in these policies to the pod subnet for this cluster
+
 ## Summary of changes made by the Calico policies
 
 Along with the default Calico policies that are applied to the public interface of worker nodes, the Calico policies in this set configure the public network for worker node and pods as follows:

--- a/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
@@ -63,6 +63,13 @@ spec:
       nets:
       - 172.20.0.0/24
     protocol: TCP
+  - action: Allow
+    destination:
+      nets:
+      # Allows communication from host to a cluster IP service.  This is need in these public
+      # policies for now due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created the cluster, use that CIDR instead.
+      - 172.30.0.0/16
   ingress:
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-ibm-ports-public.yaml
@@ -66,9 +66,10 @@ spec:
   - action: Allow
     destination:
       nets:
-      # Allows communication from host to a cluster IP service.  This is need in these public
-      # policies for now due to https://github.com/projectcalico/felix/pull/2582
-      # If you specified a custom pod subnet when you created the cluster, use that CIDR instead.
+      # Allows communication from a worker node to a ClusterIP service.  This rule is
+      # required in these public policies due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created a classic cluster, or if
+      # you use a VPC cluster, use the cluster's pod CIDR instead.
       - 172.30.0.0/16
   ingress:
   - action: Allow

--- a/calico-policies/public-network-isolation/ca-tor/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/ca-tor/allow-ibm-ports-public.yaml
@@ -61,6 +61,14 @@ spec:
       nets:
       - 172.20.0.0/24
     protocol: TCP
+  - action: Allow
+    destination:
+      nets:
+      # Allows communication from a worker node to a ClusterIP service.  This rule is
+      # required in these public policies due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created a classic cluster, or if
+      # you use a VPC cluster, use the cluster's pod CIDR instead.
+      - 172.30.0.0/16
   ingress:
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
@@ -63,6 +63,13 @@ spec:
       nets:
       - 172.20.0.0/24
     protocol: TCP
+  - action: Allow
+    destination:
+      nets:
+      # Allows communication from host to a cluster IP service.  This is need in these public
+      # policies for now due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created the cluster, use that CIDR instead.
+      - 172.30.0.0/16
   ingress:
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-ibm-ports-public.yaml
@@ -66,9 +66,10 @@ spec:
   - action: Allow
     destination:
       nets:
-      # Allows communication from host to a cluster IP service.  This is need in these public
-      # policies for now due to https://github.com/projectcalico/felix/pull/2582
-      # If you specified a custom pod subnet when you created the cluster, use that CIDR instead.
+      # Allows communication from a worker node to a ClusterIP service.  This rule is
+      # required in these public policies due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created a classic cluster, or if
+      # you use a VPC cluster, use the cluster's pod CIDR instead.
       - 172.30.0.0/16
   ingress:
   - action: Allow

--- a/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
@@ -63,6 +63,13 @@ spec:
       nets:
       - 172.20.0.0/24
     protocol: TCP
+  - action: Allow
+    destination:
+      nets:
+      # Allows communication from host to a cluster IP service.  This is need in these public
+      # policies for now due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created the cluster, use that CIDR instead.
+      - 172.30.0.0/16
   ingress:
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-ibm-ports-public.yaml
@@ -66,9 +66,10 @@ spec:
   - action: Allow
     destination:
       nets:
-      # Allows communication from host to a cluster IP service.  This is need in these public
-      # policies for now due to https://github.com/projectcalico/felix/pull/2582
-      # If you specified a custom pod subnet when you created the cluster, use that CIDR instead.
+      # Allows communication from a worker node to a ClusterIP service.  This rule is
+      # required in these public policies due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created a classic cluster, or if
+      # you use a VPC cluster, use the cluster's pod CIDR instead.
       - 172.30.0.0/16
   ingress:
   - action: Allow

--- a/calico-policies/public-network-isolation/jp-osa/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/jp-osa/allow-ibm-ports-public.yaml
@@ -64,9 +64,10 @@ spec:
   - action: Allow
     destination:
       nets:
-      # Allows communication from host to a cluster IP service.  This is need in these public
-      # policies for now due to https://github.com/projectcalico/felix/pull/2582
-      # If you specified a custom pod subnet when you created the cluster, use that CIDR instead.
+      # Allows communication from a worker node to a ClusterIP service.  This rule is
+      # required in these public policies due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created a classic cluster, or if
+      # you use a VPC cluster, use the cluster's pod CIDR instead.
       - 172.30.0.0/16
   ingress:
   - action: Allow

--- a/calico-policies/public-network-isolation/jp-osa/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/jp-osa/allow-ibm-ports-public.yaml
@@ -61,6 +61,13 @@ spec:
       nets:
       - 172.20.0.0/24
     protocol: TCP
+  - action: Allow
+    destination:
+      nets:
+      # Allows communication from host to a cluster IP service.  This is need in these public
+      # policies for now due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created the cluster, use that CIDR instead.
+      - 172.30.0.0/16
   ingress:
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
@@ -63,6 +63,13 @@ spec:
       nets:
       - 172.20.0.0/24
     protocol: TCP
+  - action: Allow
+    destination:
+      nets:
+      # Allows communication from host to a cluster IP service.  This is need in these public
+      # policies for now due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created the cluster, use that CIDR instead.
+      - 172.30.0.0/16
   ingress:
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-ibm-ports-public.yaml
@@ -66,9 +66,10 @@ spec:
   - action: Allow
     destination:
       nets:
-      # Allows communication from host to a cluster IP service.  This is need in these public
-      # policies for now due to https://github.com/projectcalico/felix/pull/2582
-      # If you specified a custom pod subnet when you created the cluster, use that CIDR instead.
+      # Allows communication from a worker node to a ClusterIP service.  This rule is
+      # required in these public policies due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created a classic cluster, or if
+      # you use a VPC cluster, use the cluster's pod CIDR instead.
       - 172.30.0.0/16
   ingress:
   - action: Allow

--- a/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
@@ -63,6 +63,13 @@ spec:
       nets:
       - 172.20.0.0/24
     protocol: TCP
+  - action: Allow
+    destination:
+      nets:
+      # Allows communication from host to a cluster IP service.  This is need in these public
+      # policies for now due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created the cluster, use that CIDR instead.
+      - 172.30.0.0/16
   ingress:
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-ibm-ports-public.yaml
@@ -66,9 +66,10 @@ spec:
   - action: Allow
     destination:
       nets:
-      # Allows communication from host to a cluster IP service.  This is need in these public
-      # policies for now due to https://github.com/projectcalico/felix/pull/2582
-      # If you specified a custom pod subnet when you created the cluster, use that CIDR instead.
+      # Allows communication from a worker node to a ClusterIP service.  This rule is
+      # required in these public policies due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created a classic cluster, or if
+      # you use a VPC cluster, use the cluster's pod CIDR instead.
       - 172.30.0.0/16
   ingress:
   - action: Allow

--- a/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
@@ -63,6 +63,13 @@ spec:
       nets:
       - 172.20.0.0/24
     protocol: TCP
+  - action: Allow
+    destination:
+      nets:
+      # Allows communication from host to a cluster IP service.  This is need in these public
+      # policies for now due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created the cluster, use that CIDR instead.
+      - 172.30.0.0/16
   ingress:
   - action: Allow
     destination:

--- a/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-ibm-ports-public.yaml
@@ -66,9 +66,10 @@ spec:
   - action: Allow
     destination:
       nets:
-      # Allows communication from host to a cluster IP service.  This is need in these public
-      # policies for now due to https://github.com/projectcalico/felix/pull/2582
-      # If you specified a custom pod subnet when you created the cluster, use that CIDR instead.
+      # Allows communication from a worker node to a ClusterIP service.  This rule is
+      # required in these public policies due to https://github.com/projectcalico/felix/pull/2582
+      # If you specified a custom pod subnet when you created a classic cluster, or if
+      # you use a VPC cluster, use the cluster's pod CIDR instead.
       - 172.30.0.0/16
   ingress:
   - action: Allow


### PR DESCRIPTION
Due to a Calico bug fixed here: https://github.com/projectcalico/felix/pull/2582 we need
to add the pod cidr to an allow egress rule, so that hosts can connect to k8s cluster IP
services.