### PR TITLE
Update stranger image version

### DIFF
--- a/gateway-clusters/ibm-external-compute-job.yaml
+++ b/gateway-clusters/ibm-external-compute-job.yaml
@@ -77,7 +77,7 @@ spec:
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
       - name: provision
-        image: &image us.icr.io/armada-master/armada-stranger:v1.0.22
+        image: &image us.icr.io/armada-master/armada-stranger:v1.0.23
         env:
         - name: IMAGE_URL
           value: *image


### PR DESCRIPTION
The v1.0.23 build includes ansible 2.10.9 which fixes PSIRTs that require 2.10.7 or later.