### PR TITLE
Added Atracker IP definitions

### DIFF
--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-private-services-pods.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-private-services-pods.yaml
@@ -70,6 +70,21 @@ spec:
       - 514
     protocol: UDP
     source: {}
+  - action: Allow
+    destination:
+      nets:
+      # IBM ATracker API : AU Syd
+      - 166.9.54.51/32
+      - 166.9.56.53/32
+      - 166.9.52.48/32
+      # IBM ATracker Ingester : AU Syd
+      - 166.9.52.49/32
+      - 166.9.56.54/32
+      - 166.9.54.52/32
+      ports:
+      - 443
+    protocol: TCP
+    source: {}
   order: 1900
   selector: projectcalico.org/orchestrator == 'k8s'
   types:

--- a/calico-policies/private-network-isolation/calico-v3/au-syd/allow-private-services.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/au-syd/allow-private-services.yaml
@@ -70,6 +70,21 @@ spec:
       - 514
     protocol: UDP
     source: {}
+  - action: Allow
+    destination:
+      nets:
+      # IBM ATracker API : AU Syd
+      - 166.9.54.51/32
+      - 166.9.56.53/32
+      - 166.9.52.48/32
+      # IBM ATracker Ingester : AU Syd
+      - 166.9.52.49/32
+      - 166.9.56.54/32
+      - 166.9.54.52/32
+      ports:
+      - 443
+    protocol: TCP
+    source: {}
   order: 1900
   selector: ibm.role == 'worker_private'
   types:

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-private-services-pods.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-private-services-pods.yaml
@@ -70,6 +70,21 @@ spec:
       - 514
     protocol: UDP
     source: {}
+  - action: Allow
+    destination:
+      nets:
+      # IBM ATracker API : US East
+      - 166.9.24.96/32
+      - 166.9.20.212/32
+      - 166.9.22.84/32
+      # IBM ATracker Ingester : US East
+      - 166.9.24.98/32
+      - 166.9.22.89/32
+      - 166.9.20.213/32
+      ports:
+      - 443
+    protocol: TCP
+    source: {}
   order: 1900
   selector: projectcalico.org/orchestrator == 'k8s'
   types:

--- a/calico-policies/private-network-isolation/calico-v3/us-east/allow-private-services.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-east/allow-private-services.yaml
@@ -70,6 +70,21 @@ spec:
       - 514
     protocol: UDP
     source: {}
+  - action: Allow
+    destination:
+      nets:
+      # IBM ATracker API : US East
+      - 166.9.24.96/32
+      - 166.9.20.212/32
+      - 166.9.22.84/32
+      # IBM ATracker Ingester : US East
+      - 166.9.24.98/32
+      - 166.9.22.89/32
+      - 166.9.20.213/32
+      ports:
+      - 443
+    protocol: TCP
+    source: {}
   order: 1900
   selector: ibm.role == 'worker_private'
   types:

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-private-services-pods.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-private-services-pods.yaml
@@ -74,6 +74,29 @@ spec:
       - 514
     protocol: UDP
     source: {}
+  - action: Allow
+    destination:
+      nets:
+      # IBM ATracker API : Prod US South
+      - 166.9.58.136/32
+      - 166.9.48.211/32
+      - 166.9.51.140/32
+      # IBM ATracker API : Stage US South
+      - 166.9.51.58/32
+      - 166.9.48.161/32
+      - 166.9.58.81/32
+      # IBM ATracker Ingester : Prod US South
+      - 166.9.51.124/32
+      - 166.9.58.121/32
+      - 166.9.48.212/32
+      # IBM ATracker Ingester : Stage US South
+      - 166.9.48.167/32
+      - 166.9.51.87/32
+      - 166.9.58.88/32
+      ports:
+      - 443
+    protocol: TCP
+    source: {}
   order: 1900
   selector: projectcalico.org/orchestrator == 'k8s'
   types:

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-private-services-pods.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-private-services-pods.yaml
@@ -81,18 +81,10 @@ spec:
       - 166.9.58.136/32
       - 166.9.48.211/32
       - 166.9.51.140/32
-      # IBM ATracker API : Stage US South
-      - 166.9.51.58/32
-      - 166.9.48.161/32
-      - 166.9.58.81/32
       # IBM ATracker Ingester : Prod US South
       - 166.9.51.124/32
       - 166.9.58.121/32
       - 166.9.48.212/32
-      # IBM ATracker Ingester : Stage US South
-      - 166.9.48.167/32
-      - 166.9.51.87/32
-      - 166.9.58.88/32
       ports:
       - 443
     protocol: TCP

--- a/calico-policies/private-network-isolation/calico-v3/us-south/allow-private-services.yaml
+++ b/calico-policies/private-network-isolation/calico-v3/us-south/allow-private-services.yaml
@@ -74,6 +74,21 @@ spec:
       - 514
     protocol: UDP
     source: {}
+  - action: Allow
+    destination:
+      nets:
+      # IBM ATracker API : Prod US South
+      - 166.9.58.136/32
+      - 166.9.48.211/32
+      - 166.9.51.140/32
+      # IBM ATracker Ingester : Prod US South
+      - 166.9.51.124/32
+      - 166.9.58.121/32
+      - 166.9.48.212/32
+      ports:
+      - 443
+    protocol: TCP
+    source: {}
   order: 1900
   selector: ibm.role == 'worker_private'
   types:


### PR DESCRIPTION
A section for Atracker private service endpoints have been added to "allow-private-services-pods.yaml" file inside calico-policies in AU-Syd, US-South and US-East regions.