### PR TITLE
Compliance operator requires .spec.description since version 0.1.40

### DIFF
--- a/roks-compliance-operator/tailoredprofile.yaml
+++ b/roks-compliance-operator/tailoredprofile.yaml
@@ -5,6 +5,7 @@ metadata:
   name: roks-cis-node
   namespace: openshift-compliance
 spec:
+  description: "ROKS specific tailoring for CO's cis-node profile"
   setValues:
     - name: ocp4-var-kubelet-evictionhard-imagefs-available
       rationale: "stricter than default"


### PR DESCRIPTION
Following the instructions at https://cloud.ibm.com/docs/openshift?topic=openshift-compliance-operator&interface=ui you'd get an error:
```
The TailoredProfile "roks-cis-node" is invalid: spec.description: Required value
```
This is because since version 0.1.40, the Compliance Operator had made the `.spec.description` field optional.