### PR TITLE
allow access to kube dashboard when using public isolation policy

### DIFF
--- a/calico-policies/public-network-isolation/au-syd/allow-k8s-master-to-dashboard.yaml
+++ b/calico-policies/public-network-isolation/au-syd/allow-k8s-master-to-dashboard.yaml
@@ -1,0 +1,25 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: allow-k8s-master-to-dashboard-via-vpn
+  namespace: kube-system
+spec:
+  order: 1000
+  # NOTE: We select the OpenVPN client/konnectivity agent pods specifically.
+  # This means they are the implicit source for egress traffic
+  # and implicit destination for ingress traffic designations.
+  selector: kubernetes-dashboard-policy == 'allow'
+  types:
+  - Egress
+  egress:
+  # Allow the vpn/konnectivity pods to forward connections
+  # from the API server to the kube-dashboard pod
+  - action: Allow
+    protocol: TCP
+    # Source is implicitly the pods selected by the policy level label selector.
+    destination:
+      selector: k8s-app == 'kubernetes-dashboard'
+      # These are the ports used by the kubernetes dashboard pod and service
+      ports:
+      - 8443
+      - 443

--- a/calico-policies/public-network-isolation/br-sao/allow-k8s-master-to-dashboard.yaml
+++ b/calico-policies/public-network-isolation/br-sao/allow-k8s-master-to-dashboard.yaml
@@ -1,0 +1,25 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: allow-k8s-master-to-dashboard-via-vpn
+  namespace: kube-system
+spec:
+  order: 1000
+  # NOTE: We select the OpenVPN client/konnectivity agent pods specifically.
+  # This means they are the implicit source for egress traffic
+  # and implicit destination for ingress traffic designations.
+  selector: kubernetes-dashboard-policy == 'allow'
+  types:
+  - Egress
+  egress:
+  # Allow the vpn/konnectivity pods to forward connections
+  # from the API server to the kube-dashboard pod
+  - action: Allow
+    protocol: TCP
+    # Source is implicitly the pods selected by the policy level label selector.
+    destination:
+      selector: k8s-app == 'kubernetes-dashboard'
+      # These are the ports used by the kubernetes dashboard pod and service
+      ports:
+      - 8443
+      - 443

--- a/calico-policies/public-network-isolation/ca-tor/allow-k8s-master-to-dashboard.yaml
+++ b/calico-policies/public-network-isolation/ca-tor/allow-k8s-master-to-dashboard.yaml
@@ -1,0 +1,25 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: allow-k8s-master-to-dashboard-via-vpn
+  namespace: kube-system
+spec:
+  order: 1000
+  # NOTE: We select the OpenVPN client/konnectivity agent pods specifically.
+  # This means they are the implicit source for egress traffic
+  # and implicit destination for ingress traffic designations.
+  selector: kubernetes-dashboard-policy == 'allow'
+  types:
+  - Egress
+  egress:
+  # Allow the vpn/konnectivity pods to forward connections
+  # from the API server to the kube-dashboard pod
+  - action: Allow
+    protocol: TCP
+    # Source is implicitly the pods selected by the policy level label selector.
+    destination:
+      selector: k8s-app == 'kubernetes-dashboard'
+      # These are the ports used by the kubernetes dashboard pod and service
+      ports:
+      - 8443
+      - 443

--- a/calico-policies/public-network-isolation/eu-de/allow-k8s-master-to-dashboard.yaml
+++ b/calico-policies/public-network-isolation/eu-de/allow-k8s-master-to-dashboard.yaml
@@ -1,0 +1,25 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: allow-k8s-master-to-dashboard-via-vpn
+  namespace: kube-system
+spec:
+  order: 1000
+  # NOTE: We select the OpenVPN client/konnectivity agent pods specifically.
+  # This means they are the implicit source for egress traffic
+  # and implicit destination for ingress traffic designations.
+  selector: kubernetes-dashboard-policy == 'allow'
+  types:
+  - Egress
+  egress:
+  # Allow the vpn/konnectivity pods to forward connections
+  # from the API server to the kube-dashboard pod
+  - action: Allow
+    protocol: TCP
+    # Source is implicitly the pods selected by the policy level label selector.
+    destination:
+      selector: k8s-app == 'kubernetes-dashboard'
+      # These are the ports used by the kubernetes dashboard pod and service
+      ports:
+      - 8443
+      - 443

--- a/calico-policies/public-network-isolation/eu-gb/allow-k8s-master-to-dashboard.yaml
+++ b/calico-policies/public-network-isolation/eu-gb/allow-k8s-master-to-dashboard.yaml
@@ -1,0 +1,25 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: allow-k8s-master-to-dashboard-via-vpn
+  namespace: kube-system
+spec:
+  order: 1000
+  # NOTE: We select the OpenVPN client/konnectivity agent pods specifically.
+  # This means they are the implicit source for egress traffic
+  # and implicit destination for ingress traffic designations.
+  selector: kubernetes-dashboard-policy == 'allow'
+  types:
+  - Egress
+  egress:
+  # Allow the vpn/konnectivity pods to forward connections
+  # from the API server to the kube-dashboard pod
+  - action: Allow
+    protocol: TCP
+    # Source is implicitly the pods selected by the policy level label selector.
+    destination:
+      selector: k8s-app == 'kubernetes-dashboard'
+      # These are the ports used by the kubernetes dashboard pod and service
+      ports:
+      - 8443
+      - 443

--- a/calico-policies/public-network-isolation/jp-osa/allow-k8s-master-to-dashboard.yaml
+++ b/calico-policies/public-network-isolation/jp-osa/allow-k8s-master-to-dashboard.yaml
@@ -1,0 +1,25 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: allow-k8s-master-to-dashboard-via-vpn
+  namespace: kube-system
+spec:
+  order: 1000
+  # NOTE: We select the OpenVPN client/konnectivity agent pods specifically.
+  # This means they are the implicit source for egress traffic
+  # and implicit destination for ingress traffic designations.
+  selector: kubernetes-dashboard-policy == 'allow'
+  types:
+  - Egress
+  egress:
+  # Allow the vpn/konnectivity pods to forward connections
+  # from the API server to the kube-dashboard pod
+  - action: Allow
+    protocol: TCP
+    # Source is implicitly the pods selected by the policy level label selector.
+    destination:
+      selector: k8s-app == 'kubernetes-dashboard'
+      # These are the ports used by the kubernetes dashboard pod and service
+      ports:
+      - 8443
+      - 443

--- a/calico-policies/public-network-isolation/jp-tok/allow-k8s-master-to-dashboard.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-k8s-master-to-dashboard.yaml
@@ -1,0 +1,25 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: allow-k8s-master-to-dashboard-via-vpn
+  namespace: kube-system
+spec:
+  order: 1000
+  # NOTE: We select the OpenVPN client/konnectivity agent pods specifically.
+  # This means they are the implicit source for egress traffic
+  # and implicit destination for ingress traffic designations.
+  selector: kubernetes-dashboard-policy == 'allow'
+  types:
+  - Egress
+  egress:
+  # Allow the vpn/konnectivity pods to forward connections
+  # from the API server to the kube-dashboard pod
+  - action: Allow
+    protocol: TCP
+    # Source is implicitly the pods selected by the policy level label selector.
+    destination:
+      selector: k8s-app == 'kubernetes-dashboard'
+      # These are the ports used by the kubernetes dashboard pod and service
+      ports:
+      - 8443
+      - 443

--- a/calico-policies/public-network-isolation/us-east/allow-k8s-master-to-dashboard.yaml
+++ b/calico-policies/public-network-isolation/us-east/allow-k8s-master-to-dashboard.yaml
@@ -1,0 +1,25 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: allow-k8s-master-to-dashboard-via-vpn
+  namespace: kube-system
+spec:
+  order: 1000
+  # NOTE: We select the OpenVPN client/konnectivity agent pods specifically.
+  # This means they are the implicit source for egress traffic
+  # and implicit destination for ingress traffic designations.
+  selector: kubernetes-dashboard-policy == 'allow'
+  types:
+  - Egress
+  egress:
+  # Allow the vpn/konnectivity pods to forward connections
+  # from the API server to the kube-dashboard pod
+  - action: Allow
+    protocol: TCP
+    # Source is implicitly the pods selected by the policy level label selector.
+    destination:
+      selector: k8s-app == 'kubernetes-dashboard'
+      # These are the ports used by the kubernetes dashboard pod and service
+      ports:
+      - 8443
+      - 443

--- a/calico-policies/public-network-isolation/us-south/allow-k8s-master-to-dashboard.yaml
+++ b/calico-policies/public-network-isolation/us-south/allow-k8s-master-to-dashboard.yaml
@@ -1,0 +1,25 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: allow-k8s-master-to-dashboard-via-vpn
+  namespace: kube-system
+spec:
+  order: 1000
+  # NOTE: We select the OpenVPN client/konnectivity agent pods specifically.
+  # This means they are the implicit source for egress traffic
+  # and implicit destination for ingress traffic designations.
+  selector: kubernetes-dashboard-policy == 'allow'
+  types:
+  - Egress
+  egress:
+  # Allow the vpn/konnectivity pods to forward connections
+  # from the API server to the kube-dashboard pod
+  - action: Allow
+    protocol: TCP
+    # Source is implicitly the pods selected by the policy level label selector.
+    destination:
+      selector: k8s-app == 'kubernetes-dashboard'
+      # These are the ports used by the kubernetes dashboard pod and service
+      ports:
+      - 8443
+      - 443


### PR DESCRIPTION
- do not block access to the kube-dashboard from the k8s master (via OpenVPN or konnectivity) when using public-isolation policies

TODO: Update docs to reflect this new policy