### PR TITLE
Add au-syd registry public IPs to jp-tok and jp-osa

### DIFF
--- a/calico-policies/public-network-isolation/jp-osa/allow-public-services-pods.yaml
+++ b/calico-policies/public-network-isolation/jp-osa/allow-public-services-pods.yaml
@@ -15,13 +15,16 @@ spec:
       - 169.60.98.80/29
       - 169.62.37.240/29
       - 169.63.104.232/29
-      # IBM Cloud Container Registry: AP North, Osaka nets for your own registry
+      # IBM Cloud Container Registry: AP North, Osaka, AP South nets for your own registry
       - 163.68.67.32/28
       - 163.69.67.0/28
       - 163.73.67.64/28
       - 128.168.71.64/29
       - 161.202.146.80/29
       - 165.192.71.216/29
+      - 130.198.88.128/29
+      - 135.90.66.48/29
+      - 168.1.1.240/29
       ports:
       - 443
       - 4443

--- a/calico-policies/public-network-isolation/jp-osa/allow-public-services.yaml
+++ b/calico-policies/public-network-isolation/jp-osa/allow-public-services.yaml
@@ -15,13 +15,16 @@ spec:
       - 169.60.98.80/29
       - 169.62.37.240/29
       - 169.63.104.232/29
-      # IBM Cloud Container Registry: AP North, Osaka nets for your own registry
+      # IBM Cloud Container Registry: AP North, Osaka, AP South nets for your own registry
       - 163.68.67.32/28
       - 163.69.67.0/28
       - 163.73.67.64/28
       - 128.168.71.64/29
       - 161.202.146.80/29
       - 165.192.71.216/29
+      - 130.198.88.128/29
+      - 135.90.66.48/29
+      - 168.1.1.240/29
       ports:
       - 443
       - 4443

--- a/calico-policies/public-network-isolation/jp-tok/allow-public-services-pods.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-public-services-pods.yaml
@@ -15,10 +15,13 @@ spec:
       - 169.60.98.80/29
       - 169.62.37.240/29
       - 169.63.104.232/29
-      # IBM Cloud Container Registry: AP North nets for your own registry
+      # IBM Cloud Container Registry: AP North, AP South nets for your own registry
       - 128.168.71.64/29
       - 161.202.146.80/29
       - 165.192.71.216/29
+      - 130.198.88.128/29
+      - 135.90.66.48/29
+      - 168.1.1.240/29
       ports:
       - 443
       - 4443

--- a/calico-policies/public-network-isolation/jp-tok/allow-public-services.yaml
+++ b/calico-policies/public-network-isolation/jp-tok/allow-public-services.yaml
@@ -15,10 +15,13 @@ spec:
       - 169.60.98.80/29
       - 169.62.37.240/29
       - 169.63.104.232/29
-      # IBM Cloud Container Registry: AP North nets for your own registry
+      # IBM Cloud Container Registry: AP North, AP South nets for your own registry
       - 128.168.71.64/29
       - 161.202.146.80/29
       - 165.192.71.216/29
+      - 130.198.88.128/29
+      - 135.90.66.48/29
+      - 168.1.1.240/29
       ports:
       - 443
       - 4443


### PR DESCRIPTION
Since jp-tok and jp-osa clusters pull their infrastructure pods
such as calico, coredns, and others from the au-syd registry, we
should add the au-syd public registry IPs to these region's policies.

This is similar to PR https://github.com/IBM-Cloud/kube-samples/pull/207/
which added the au-syd private registry IPs.