### PR TITLE
http-snippet removal

### DIFF
--- a/ingress-config/ibm-k8s-controller-config.yaml
+++ b/ingress-config/ibm-k8s-controller-config.yaml
@@ -8,43 +8,6 @@ data:
   client-body-buffer-size: 128k
   enable-multi-accept: "false"
   enable-underscores-in-headers: "true"
-  http-snippet: |
-    server {
-    	listen %[1]d;
-    	listen [::]:%[1]d;
-    	location / {
-    		add_header Content-Type text/plain;
-    		return 200 'healthy';
-    	}
-    }
-    server {
-    	listen %[2]d default_server;
-    	listen [::]:%[2]d default_server;
-    	location / {
-    		default_type text/html;
-    		return 404 '<html><h1>Error 404</h1><br/>Page Not Found</html>';
-    	}
-    }
-    map $upstream_status $sanitized_upstream_status {
-    	default  $upstream_status;
-    	''       -1;
-    	'-'      -1;
-    }
-    map $upstream_response_time $sanitized_upstream_response_time {
-    	default  $upstream_response_time;
-    	''       -1;
-    	'-'      -1;
-    }
-    map $upstream_connect_time $sanitized_upstream_connect_time {
-    	default  $upstream_connect_time;
-    	''       -1;
-    	'-'      -1;
-    }
-    map $upstream_header_time $sanitized_upstream_header_time {
-    	default  $upstream_header_time;
-    	''       -1;
-    	'-'      -1;
-    }
   map-hash-bucket-size: "128"
   max-worker-connections: "64510"
   proxy-body-size: 2m


### PR DESCRIPTION
This PR contains updates to `ibm-k8s-controller-config` ConfigMap.

These changes will be effective to new and existing IKS clusters on 3 October 2022.