### PR TITLE
Remove old Container Registry private IPs from calico samples

### DIFF
--- a/calico-policies/private-network-isolation/au-syd/allow-private-services-pods.yaml
+++ b/calico-policies/private-network-isolation/au-syd/allow-private-services-pods.yaml
@@ -12,19 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: AP South nets for your own registry
-      - 166.9.52.20/32
-      - 166.9.54.19/32
-      - 166.9.56.13/32
-      # IBM Cloud Container Registry: Global registry new subnets
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: AP South registry new subnets
+      # IBM Cloud Container Registry: AP South registry subnets
       - 166.9.244.106/32
       - 166.9.244.136/32
       - 166.9.244.170/32

--- a/calico-policies/private-network-isolation/au-syd/allow-private-services.yaml
+++ b/calico-policies/private-network-isolation/au-syd/allow-private-services.yaml
@@ -12,19 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: AP South nets for your own registry
-      - 166.9.52.20/32
-      - 166.9.54.19/32
-      - 166.9.56.13/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New AP South nets for your own registry
+      # IBM Cloud Container Registry: AP South registry subnets
       - 166.9.244.106/32
       - 166.9.244.136/32
       - 166.9.244.170/32

--- a/calico-policies/private-network-isolation/br-sao/allow-private-services-pods.yaml
+++ b/calico-policies/private-network-isolation/br-sao/allow-private-services-pods.yaml
@@ -12,22 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: US South, US East, and São Paulo nets for your own registry
-      - 166.9.12.227/32
-      - 166.9.15.116/32
-      - 166.9.16.244/32
-      - 166.9.82.13/32
-      - 166.9.83.13/32
-      - 166.9.84.13/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New US South, US East, and São Paulo nets for your own registry
+      # IBM Cloud Container Registry: US South and São Paulo subnets
       - 166.9.250.214/32
       - 166.9.250.246/32
       - 166.9.251.21/32

--- a/calico-policies/private-network-isolation/br-sao/allow-private-services.yaml
+++ b/calico-policies/private-network-isolation/br-sao/allow-private-services.yaml
@@ -12,22 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: US South, US East, and São Paulo nets for your own registry
-      - 166.9.12.227/32
-      - 166.9.15.116/32
-      - 166.9.16.244/32
-      - 166.9.82.13/32
-      - 166.9.83.13/32
-      - 166.9.84.13/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New US South, US East, and São Paulo nets for your own registry
+      # IBM Cloud Container Registry: US South and São Paulo subnets
       - 166.9.250.214/32
       - 166.9.250.246/32
       - 166.9.251.21/32

--- a/calico-policies/private-network-isolation/ca-tor/allow-private-services-pods.yaml
+++ b/calico-policies/private-network-isolation/ca-tor/allow-private-services-pods.yaml
@@ -12,22 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: US South, US East, Toronto nets for your own registry
-      - 166.9.76.12/32
-      - 166.9.77.11/32
-      - 166.9.78.11/32
-      - 166.9.12.227/32
-      - 166.9.15.116/32
-      - 166.9.16.244/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New US South, US East, Toronto nets for your own registry
+      # IBM Cloud Container Registry: US South, Toronto subnets
       - 166.9.250.214/32
       - 166.9.250.246/32
       - 166.9.251.21/32

--- a/calico-policies/private-network-isolation/ca-tor/allow-private-services.yaml
+++ b/calico-policies/private-network-isolation/ca-tor/allow-private-services.yaml
@@ -12,22 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: US South, US East, Toronto nets for your own registry
-      - 166.9.76.12/32
-      - 166.9.77.11/32
-      - 166.9.78.11/32
-      - 166.9.12.227/32
-      - 166.9.15.116/32
-      - 166.9.16.244/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New US South, US East, Toronto nets for your own registry
+      # IBM Cloud Container Registry: US South, Toronto subnets
       - 166.9.250.214/32
       - 166.9.250.246/32
       - 166.9.251.21/32

--- a/calico-policies/private-network-isolation/eu-de/allow-private-services-pods.yaml
+++ b/calico-policies/private-network-isolation/eu-de/allow-private-services-pods.yaml
@@ -12,19 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: EU Central nets for your own registry
-      - 166.9.28.35/32
-      - 166.9.30.2/32
-      - 166.9.32.2/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New EU Central nets for your own registry
+      # IBM Cloud Container Registry: EU Central registry subnets
       - 166.9.248.76/32
       - 166.9.248.105/32
       - 166.9.248.136/32

--- a/calico-policies/private-network-isolation/eu-de/allow-private-services.yaml
+++ b/calico-policies/private-network-isolation/eu-de/allow-private-services.yaml
@@ -12,19 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: EU Central nets for your own registry
-      - 166.9.28.35/32
-      - 166.9.30.2/32
-      - 166.9.32.2/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New EU Central nets for your own registry
+      # IBM Cloud Container Registry: EU Central registry subnets
       - 166.9.248.76/32
       - 166.9.248.105/32
       - 166.9.248.136/32

--- a/calico-policies/private-network-isolation/eu-gb/allow-private-services-pods.yaml
+++ b/calico-policies/private-network-isolation/eu-gb/allow-private-services-pods.yaml
@@ -12,19 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: UK South nets for your own registry
-      - 166.9.34.12/32
-      - 166.9.36.19/32
-      - 166.9.38.14/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New UK South nets for your own registry
+      # IBM Cloud Container Registry: UK South registry subnets
       - 166.9.244.9/32
       - 166.9.244.45/32
       - 166.9.244.73/32

--- a/calico-policies/private-network-isolation/eu-gb/allow-private-services.yaml
+++ b/calico-policies/private-network-isolation/eu-gb/allow-private-services.yaml
@@ -12,19 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: UK South nets for your own registry
-      - 166.9.34.12/32
-      - 166.9.36.19/32
-      - 166.9.38.14/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New UK South nets for your own registry
+      # IBM Cloud Container Registry: UK South registry subnets
       - 166.9.244.9/32
       - 166.9.244.45/32
       - 166.9.244.73/32

--- a/calico-policies/private-network-isolation/jp-osa/allow-private-services-pods.yaml
+++ b/calico-policies/private-network-isolation/jp-osa/allow-private-services-pods.yaml
@@ -12,22 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: AP North, Osaka nets for your own registry
-      - 166.9.70.4/32
-      - 166.9.71.5/32
-      - 166.9.72.6/32
-      - 166.9.40.20/32
-      - 166.9.42.21/32
-      - 166.9.44.12/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New AP North, Osaka, AP South nets for your own registry
+      # IBM Cloud Container Registry: Osaka, AP North, AP South registry subnets
       - 166.9.247.39/32
       - 166.9.247.73/32
       - 166.9.247.105/32

--- a/calico-policies/private-network-isolation/jp-osa/allow-private-services.yaml
+++ b/calico-policies/private-network-isolation/jp-osa/allow-private-services.yaml
@@ -12,22 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: AP North, Osaka nets for your own registry
-      - 166.9.70.4/32
-      - 166.9.71.5/32
-      - 166.9.72.6/32
-      - 166.9.40.20/32
-      - 166.9.42.21/32
-      - 166.9.44.12/32
-      # IBM Cloud Container Registry: New Global registry
-      - 166.9.251.49/32
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.82/32
+      - 166.9.251.49/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New AP North, Osaka, AP South nets for your own registry
+      # IBM Cloud Container Registry: Osaka, AP North, AP South registry subnets
       - 166.9.247.39/32
       - 166.9.247.73/32
       - 166.9.247.105/32

--- a/calico-policies/private-network-isolation/jp-tok/allow-private-services-pods.yaml
+++ b/calico-policies/private-network-isolation/jp-tok/allow-private-services-pods.yaml
@@ -12,19 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: AP North nets for your own registry
-      - 166.9.40.20/32
-      - 166.9.42.21/32
-      - 166.9.44.12/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New AP North, AP South nets for your own registry
+      # IBM Cloud Container Registry: AP North, AP South registry subnets
       - 166.9.249.104/32
       - 166.9.249.157/32
       - 166.9.249.168/32

--- a/calico-policies/private-network-isolation/jp-tok/allow-private-services.yaml
+++ b/calico-policies/private-network-isolation/jp-tok/allow-private-services.yaml
@@ -12,19 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: AP North nets for your own registry
-      - 166.9.40.20/32
-      - 166.9.42.21/32
-      - 166.9.44.12/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New AP North, AP South nets for your own registry
+      # IBM Cloud Container Registry: AP North, AP South registry subnets
       - 166.9.249.104/32
       - 166.9.249.157/32
       - 166.9.249.168/32

--- a/calico-policies/private-network-isolation/us-east/allow-private-services-pods.yaml
+++ b/calico-policies/private-network-isolation/us-east/allow-private-services-pods.yaml
@@ -12,19 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: US South & US East nets for your own registry
-      - 166.9.12.227/32
-      - 166.9.15.116/32
-      - 166.9.16.244/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New US South & US East nets for your own registry
+      # IBM Cloud Container Registry: US South registry subnets
       - 166.9.250.214/32
       - 166.9.250.246/32
       - 166.9.251.21/32

--- a/calico-policies/private-network-isolation/us-east/allow-private-services.yaml
+++ b/calico-policies/private-network-isolation/us-east/allow-private-services.yaml
@@ -12,19 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: US South & US East nets for your own registry
-      - 166.9.12.227/32
-      - 166.9.15.116/32
-      - 166.9.16.244/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New US South & US East nets for your own registry
+      # IBM Cloud Container Registry: US South registry subnets
       - 166.9.250.214/32
       - 166.9.250.246/32
       - 166.9.251.21/32

--- a/calico-policies/private-network-isolation/us-south/allow-private-services-pods.yaml
+++ b/calico-policies/private-network-isolation/us-south/allow-private-services-pods.yaml
@@ -12,19 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: US South & US East nets for your own registry
-      - 166.9.12.227/32
-      - 166.9.15.116/32
-      - 166.9.16.244/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New US South & US East nets for your own registry
+      # IBM Cloud Container Registry: US South registry subnets
       - 166.9.250.214/32
       - 166.9.250.246/32
       - 166.9.251.21/32

--- a/calico-policies/private-network-isolation/us-south/allow-private-services.yaml
+++ b/calico-policies/private-network-isolation/us-south/allow-private-services.yaml
@@ -12,19 +12,11 @@ spec:
   - action: Allow
     destination:
       nets:
-      # IBM Cloud Container Registry: Global registry
-      - 166.9.20.31/32
-      - 166.9.22.22/32
-      - 166.9.24.16/32
-      # IBM Cloud Container Registry: US South & US East nets for your own registry
-      - 166.9.12.227/32
-      - 166.9.15.116/32
-      - 166.9.16.244/32
-      # IBM Cloud Container Registry: New Global registry
+      # IBM Cloud Container Registry: Global (US East) registry subnets
       - 166.9.251.49/32
       - 166.9.251.82/32
       - 166.9.251.113/32
-      # IBM Cloud Container Registry: New US South & US East nets for your own registry
+      # IBM Cloud Container Registry: US South registry subnets
       - 166.9.250.214/32
       - 166.9.250.246/32
       - 166.9.251.21/32


### PR DESCRIPTION
This PR removes from calico policies the old Container Registry IP addresses which are deprecated and being decommissioned on December 15th as per the announcement [here](https://cloud.ibm.com/docs/Registry?topic=Registry-registry_notices_ip_address). **Please do not merge this before the December 15th.**

Also fixed up some comments for clarity and consistency.


