### PR TITLE
kube-bench: Update to v0.6.11

### DIFF
--- a/cis-kube-benchmark/cis-1.5/ibm/config.yaml
+++ b/cis-kube-benchmark/cis-1.5/ibm/config.yaml
@@ -1,5 +1,13 @@
 ---
 node:
+  components:
+    - kubelet
+    - proxy
+    - kubernetes
+
+  kubernetes:
+    defaultconf: "/etc/kubernetes/config"
+
   kubelet:
     bins:
     - hyperkube kubelet
@@ -10,6 +18,11 @@ node:
     - /etc/kubernetes/kubelet.conf
     - /etc/kubernetes/kubelet-config.yaml
     - /lib/systemd/system/kubelet.service
+    cafile:
+    - "/etc/kubernetes/pki/ca.crt"
+    - "/etc/kubernetes/certs/ca.crt"
+    - "/etc/kubernetes/cert/ca.pem"
+    - "/var/snap/microk8s/current/certs/ca.crt"
     defaultconf: /etc/kubernetes/kubelet.conf
     defaultkubeconfig: /etc/kubernetes/kubelet-kubeconfig
     defaultsvc: /lib/systemd/system/kubelet.service
@@ -24,3 +37,13 @@ node:
     defaultconf: /etc/kubernetes/kubelet.conf
     defaultkubeconfig: /etc/kubernetes/kubelet-kubeconfig
     defaultsvc: /lib/systemd/system/kube-proxy.service
+
+policies:
+  components: []
+
+managedservices:
+  components: []
+
+target_mapping:
+  "ibm":
+    - "node"

--- a/cis-kube-benchmark/cis-1.5/ibm/job-node.yaml
+++ b/cis-kube-benchmark/cis-1.5/ibm/job-node.yaml
@@ -79,8 +79,8 @@ spec:
       hostPID: true
       containers:
       - name: kube-bench
-        image: docker.io/aquasec/kube-bench:0.2.3
-        command: ["kube-bench", "--v=2", "node", "--benchmark", "ibm"]
+        image: docker.io/aquasec/kube-bench:v0.6.11
+        command: ["kube-bench", "run", "--targets", "node", "--v=2", "--benchmark", "ibm", "--config", "/opt/kube-bench/cfg/ibm/config.yaml"]
         volumeMounts:
         - name: var-lib-kubelet
           mountPath: /var/lib/kubelet


### PR DESCRIPTION
Update version of kube-bench to v0.6.11 which has multi-arch support. Requires additional changes to configuration file to run from custom `ibm` benchmark.