### PR TITLE
Add codeowners for calico-policies

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,5 +5,5 @@
 * @ghost # ghost just means "no users"
 
 # calico-policies owners
-/calico-policies/ @bradbehle @Tamas-Biro1 @kersten1 @derekpoindexter
+/calico-policies/ @bradbehle @Tamas-Biro1 @kersten1 @derekpoindexter @mihivagyok @ctrath @calvinrzachman
 


### PR DESCRIPTION
Adding a few more code owners for the calico-policies from the network team, since we need two code owners to approve any PRs, and these additional people are qualified to review and approve these policies