### PR TITLE
Update CIS Benchmark Config

### DIFF
--- a/cis-kube-benchmark/cis-1.5/ibm/config.yaml
+++ b/cis-kube-benchmark/cis-1.5/ibm/config.yaml
@@ -41,6 +41,7 @@ node:
     - hyperkube proxy
     - hyperkube kube-proxy
     - kube-proxy
+    - ovnkube
     svc:
     - /lib/systemd/system/kube-proxy.service
     kubeconfig:


### PR DESCRIPTION
This PR updates the CIS Benchmark test to list `ovnkube` as a valid binary option for the `proxy` component. This is required to get around weird behavior in the benchmark test that occurs when a binary for the `proxy` component cannot be found. 