### PR TITLE
Update ingress configmap

### DIFF
--- a/ingress-config/ibm-k8s-controller-config.yaml
+++ b/ingress-config/ibm-k8s-controller-config.yaml
@@ -4,7 +4,9 @@ metadata:
   name: ibm-k8s-controller-config
   namespace: kube-system
 data:
+  allow-cross-namespace-resources: "true"
   allow-snippet-annotations: "false"
+  annotations-risk-level: Critical
   client-body-buffer-size: 128k
   enable-multi-accept: "false"
   enable-underscores-in-headers: "true"


### PR DESCRIPTION
This PR is add 2 new default annotations to ingress configmap:
- `allow-cross-namespace-resources: "true"`
- `annotations-risk-level: Critical`