### PR TITLE
Add CIS Benchmark v1.12 sample

### DIFF
--- a/cis-kube-benchmark/README.md
+++ b/cis-kube-benchmark/README.md
@@ -1,0 +1,26 @@
+# Running the `cis-kube-benchmark` sample
+
+## Creating the configmap
+
+Before running a CIS Benchmark sample, create a configmap that holds the configuration files:
+
+```shell
+kubectl create namespace ibm-kube-bench-test
+
+# Adjust paths to the correct CIS Benchmark version:
+kubectl create configmap -n ibm-kube-bench-test kube-bench-node \
+  --from-file=config.yaml="cis-kube-benchmark/cis-1.12/ibm/config.yaml" \
+  --from-file=node.yaml="cis-kube-benchmark/cis-1.12/ibm/node.yaml"
+```
+
+## Running the job
+
+Apply the manifests, wait for the job to complete, and inspect the results:
+
+```shell
+# Adjust path to the correct CIS Benchmark version:
+kubectl apply -f cis-kube-benchmark/cis-1.12/ibm/job-node.yaml
+
+# Fetch the results when the job is complete:
+kubectl logs -n ibm-kube-bench-test -l job-name=kube-bench-node --tail -1
+```

--- a/cis-kube-benchmark/cis-1.12/ibm/config.yaml
+++ b/cis-kube-benchmark/cis-1.12/ibm/config.yaml
@@ -1,0 +1,62 @@
+---
+node:
+  components:
+    - kubelet
+    - proxy
+    - kubernetes
+
+  kubernetes:
+    confs:
+    - "/etc/kubernetes/config"
+    - "/etc/kubernetes/kubelet.conf"
+    defaultconf: "/etc/kubernetes/config"
+
+  kubelet:
+    bins:
+    - hyperkube kubelet
+    - kubelet
+    svc:
+    - /lib/systemd/system/kubelet.service
+    - /etc/systemd/system/kubelet.service
+    cafile:
+      - "/etc/kubernetes/pki/ca.crt"
+      - "/etc/kubernetes/certs/ca.crt"
+      - "/etc/kubernetes/cert/ca.pem"
+      - "/var/lib/kubelet/pki/kubelet-client-current.pem"
+      - "/var/lib/kubelet/pki/kubelet-server-current.pem"
+    confs:
+    - /etc/kubernetes/kubelet.conf
+    - /etc/kubernetes/kubelet-config.yaml
+    - /lib/systemd/system/kubelet.service
+    - /etc/systemd/system/kubelet.service
+    kubeconfig:
+    - /etc/kubernetes/kubelet-kubeconfig
+    - /var/lib/kubelet/kubeconfig
+    defaultconf: /etc/kubernetes/kubelet.conf
+    defaultsvc: /lib/systemd/system/kubelet.service
+    defaultkubeconfig: /etc/kubernetes/kubelet-kubeconfig
+
+  proxy:
+    bins:
+    - hyperkube proxy
+    - hyperkube kube-proxy
+    - kube-proxy
+    - ovnkube
+    svc:
+    - /lib/systemd/system/kube-proxy.service
+    kubeconfig:
+    - /etc/kubernetes/kubelet-kubeconfig
+    - /var/lib/kubelet/kubeconfig
+    defaultconf: /etc/kubernetes/kubelet.conf
+    defaultsvc: /lib/systemd/system/kube-proxy.service
+    defaultkubeconfig: /etc/kubernetes/kubelet-kubeconfig
+
+policies:
+  components: []
+
+managedservices:
+  components: []
+
+target_mapping:
+  "ibm":
+    - "node"

--- a/cis-kube-benchmark/cis-1.12/ibm/job-node.yaml
+++ b/cis-kube-benchmark/cis-1.12/ibm/job-node.yaml
@@ -1,0 +1,112 @@
+# NOTE: IBM Cloud Kubernetes Services versions 1.23 and earlier
+# use pod security policies (PSPs) for pod security. Version 1.24 uses
+# PSPs by default and can optionally use pod security admission. Versions
+# 1.25 and later use pod security admission only. Red Hat OpenShift on
+# IBM Cloud uses security context constraints (SCCs) for pod security.
+# And starting with version 4.11, pod security admission is also used.
+# The Kubernetes resources in this file handle all of these pod security
+# use cases.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ibm-kube-bench-test
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-bench-node
+  namespace: ibm-kube-bench-test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kube-bench-node-psp
+  namespace: ibm-kube-bench-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ibm-privileged-psp-user
+subjects:
+- kind: ServiceAccount
+  name: kube-bench-node
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kube-bench-node-scc
+  namespace: ibm-kube-bench-test
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - ibm-privileged-scc
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kube-bench-node-scc
+  namespace: ibm-kube-bench-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-bench-node-scc
+subjects:
+- kind: ServiceAccount
+  name: kube-bench-node
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kube-bench-node
+  namespace: ibm-kube-bench-test
+spec:
+  template:
+    spec:
+      serviceAccountName: kube-bench-node
+      hostPID: true
+      containers:
+      - name: kube-bench
+        image: docker.io/aquasec/kube-bench:v0.15.0
+        command: ["kube-bench", "run", "--targets", "node", "--v=2", "--benchmark", "ibm", "--config", "/opt/kube-bench/cfg/ibm/config.yaml"]
+        volumeMounts:
+        - name: var-lib-kubelet
+          mountPath: /var/lib/kubelet
+        - name: lib-systemd-system
+          mountPath: /lib/systemd/system
+        - name: etc-systemd-system
+          mountPath: /etc/systemd/system
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+        - name: config
+          mountPath: /opt/kube-bench/cfg/ibm
+          readOnly: true
+      restartPolicy: Never
+      volumes:
+      - name: var-lib-kubelet
+        hostPath:
+          path: "/var/lib/kubelet"
+      - name: lib-systemd-system
+        hostPath:
+          path: "/lib/systemd/system"
+      - name: etc-systemd-system
+        hostPath:
+          path: "/etc/systemd/system"
+      - name: etc-kubernetes
+        hostPath:
+          path: "/etc/kubernetes"
+      - name: config
+        configMap:
+          name: kube-bench-node

--- a/cis-kube-benchmark/cis-1.12/ibm/node.yaml
+++ b/cis-kube-benchmark/cis-1.12/ibm/node.yaml
@@ -1,0 +1,529 @@
+---
+controls:
+version: "cis-1.12"
+id: 4
+text: "Worker Node Security Configuration"
+type: "node"
+groups:
+  - id: 4.1
+    text: "Worker Node Configuration Files"
+    checks:
+      - id: 4.1.1
+        text: "Ensure that the kubelet service file permissions are set to 600 or more
+          restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $kubeletsvc; then stat -c permissions=%a
+          $kubeletsvc; fi' "
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example, chmod 600 $kubeletsvc
+        scored: true
+
+      - id: 4.1.2
+        text: "Ensure that the kubelet service file ownership is set to root:root
+          (Automated)"
+        audit: "/bin/sh -c \"if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc;
+          else echo \\\"File not found\\\"; fi\""
+        tests:
+          bin_op: or
+          test_items:
+            - flag: root:root
+            - flag: "File not found"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletsvc
+        scored: true
+
+      - id: 4.1.3
+        text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more
+          restrictive (Manual)"
+        audit: "/bin/sh -c 'if test -e $proxykubeconfig; then stat -c permissions=%a
+          $proxykubeconfig; fi' "
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "permissions"
+              set: true
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 600 $proxykubeconfig
+        scored: false
+
+      - id: 4.1.4
+        text: "If proxy kubeconfig file exists ensure ownership is set to root:root
+          (Manual)"
+        audit: "/bin/sh -c 'if test -e $proxykubeconfig; then stat -c %U:%G
+          $proxykubeconfig; fi' "
+        tests:
+          bin_op: or
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example, chown root:root $proxykubeconfig
+        scored: false
+
+      - id: 4.1.5
+        text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600
+          or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $kubeletkubeconfig; then stat -c permissions=%a
+          $kubeletkubeconfig; fi' "
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 600 $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.6
+        text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to
+          root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $kubeletkubeconfig; then stat -c %U:%G
+          $kubeletkubeconfig; fi' "
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.7
+        text: "Ensure that the certificate authorities file permissions are set to 644
+          or more restrictive (Manual)"
+        audit: |
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
+          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
+          if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the following command to modify the file permissions of the
+          --client-ca-file chmod 644 <filename>
+        scored: false
+
+      - id: 4.1.8
+        text: "Ensure that the client certificate authorities file ownership is set to
+          root:root (Manual)"
+        audit: |
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}' | uniq)
+          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
+          if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
+        tests:
+          test_items:
+            - flag: root:root
+              compare:
+                op: eq
+                value: root:root
+        remediation: |
+          Run the following command to modify the ownership of the --client-ca-file.
+          chown root:root <filename>
+        scored: false
+
+      - id: 4.1.9
+        text: "If the kubelet config.yaml configuration file is being used validate
+          permissions set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c permissions=%a
+          $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the following command (using the config file location identified in the Audit step)
+          chmod 600 $kubeletconf
+        scored: true
+
+      - id: 4.1.10
+        text: "If the kubelet config.yaml configuration file is being used validate file
+          ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $kubeletconf; then stat -c %U:%G $kubeletconf;
+          fi' "
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the following command (using the config file location identified in the Audit step)
+          chown root:root $kubeletconf
+        scored: true
+
+  - id: 4.2
+    text: "Kubelet"
+    checks:
+      - id: 4.2.1
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              path: "{.authentication.anonymous.enabled}"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set `authentication: anonymous: enabled` to
+          `false`.
+          If using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          `--anonymous-auth=false`
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.2
+        # Modified check: --authorization-mode defaults to "Webhook" if unset AND kubelet is configured with a config file.
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow
+          (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: --authorization-mode
+              path: "{.authorization.mode}"
+              compare:
+                op: nothave
+                value: AlwaysAllow
+            - flag: --authorization-mode
+              path: "{.authorization.mode}"
+              set: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set `authorization.mode` to Webhook. If
+          using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --authorization-mode=Webhook
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.3
+        text: "Ensure that the --client-ca-file argument is set as appropriate
+          (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --client-ca-file
+              path: "{.authentication.x509.clientCAFile}"
+        remediation: |
+          If using a Kubelet config file, edit the file to set `authentication.x509.clientCAFile` to
+          the location of the client CA file.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --client-ca-file=<path/to/client-ca-file>
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.4
+        text: "Verify that if defined, the --read-only-port argument is set to 0
+          (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--read-only-port"
+              path: "{.readOnlyPort}"
+              compare:
+                op: eq
+                value: 0
+            - flag: "--read-only-port"
+              path: "{.readOnlyPort}"
+              set: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set `readOnlyPort` to 0.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --read-only-port=0
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.5
+        text: "Ensure that the --streaming-connection-idle-timeout argument is not set
+          to 0 (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --streaming-connection-idle-timeout
+              path: "{.streamingConnectionIdleTimeout}"
+              compare:
+                op: noteq
+                value: 0
+            - flag: --streaming-connection-idle-timeout
+              path: "{.streamingConnectionIdleTimeout}"
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a
+          value other than 0.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --streaming-connection-idle-timeout=5m
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.6
+        text: "Ensure that the --make-iptables-util-chains argument is set to true
+          (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --make-iptables-util-chains
+              path: "{.makeIPTablesUtilChains}"
+              compare:
+                op: eq
+                value: true
+            - flag: --make-iptables-util-chains
+              path: "{.makeIPTablesUtilChains}"
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set `makeIPTablesUtilChains` to `true`.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          remove the --make-iptables-util-chains argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.7
+        text: "Ensure that the --hostname-override argument is not set (Manual)"
+        # This is one of those properties that can only be set as a command line argument.
+        # To check if the property is set as expected, we need to parse the kubelet command
+        # instead reading the Kubelet Configuration file.
+        audit: "/bin/ps -fC $kubeletbin"
+        tests:
+          test_items:
+            - flag: --hostname-override
+              set: false
+        remediation: |
+          Edit the kubelet service file $kubeletsvc
+          on each worker node and remove the --hostname-override argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.8
+        text: "Ensure that the eventRecordQPS argument is set to a level which ensures
+          appropriate event capture (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --event-qps
+              path: "{.eventRecordQPS}"
+              compare:
+                op: eq
+                value: 0
+            - flag: --event-qps
+              path: "{.eventRecordQPS}"
+              compare:
+                op: eq
+                value: 50
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set `eventRecordQPS` to an appropriate level.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.9
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are
+          set as appropriate (Manual)"
+        # Note: ROKS RHCOS worker nodes use the default location of /var/lib/kubelet/pki and do not explicitly set these arguments.
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --tls-cert-file
+              path: "{.tlsCertFile}"
+            - flag: --tls-private-key-file
+              path: "{.tlsPrivateKeyFile}"
+            - path: '{.serverTLSBootstrap}'
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set `tlsCertFile` to the location
+          of the certificate file to use to identify this Kubelet, and `tlsPrivateKeyFile`
+          to the location of the corresponding private key file.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
+          --tls-cert-file=<path/to/tls-certificate-file>
+          --tls-private-key-file=<path/to/tls-key-file>
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.10
+        # Modified check: --rotate-certificates is false if it's unset.
+        text: "Ensure that the --rotate-certificates argument is not set to false
+          (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --rotate-certificates
+              path: "{.rotateCertificates}"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          If using a Kubelet config file, edit the file to add the line `rotateCertificates` to `true` or
+          remove it altogether to use the default value.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
+          variable.
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.11
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true
+          (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: RotateKubeletServerCertificate
+              path: "{.featureGates.RotateKubeletServerCertificate}"
+              compare:
+                op: nothave
+                value: false
+            - flag: RotateKubeletServerCertificate
+              path: "{.featureGates.RotateKubeletServerCertificate}"
+              set: false
+        remediation: |
+          Edit the kubelet service file $kubeletsvc
+          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
+          --feature-gates=RotateKubeletServerCertificate=true
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.12
+        text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers
+          (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --tls-cipher-suites
+              path: "{range .tlsCipherSuites[:]}{}{','}{end}"
+              compare:
+                op: valid_elements
+                value: TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        remediation: |
+          If using a Kubelet config file, edit the file to set `tlsCipherSuites` to
+          TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+          or to a subset of these values.
+          If using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
+          --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.13
+        text: "Ensure that a limit is set on pod PIDs (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --pod-max-pids
+              path: "{.podPidsLimit}"
+        remediation: |
+          Decide on an appropriate level for this parameter and set it,
+          either via the --pod-max-pids command line parameter or the PodPidsLimit configuration file setting.
+        scored: false
+
+      - id: 4.2.14
+        text: "Ensure that the --seccomp-default parameter is set to true (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --seccomp-default
+              path: "{.seccompDefault}"
+        remediation: |
+          Set the parameter, either via the --seccomp-default command line parameter or the
+          seccompDefault configuration file setting.
+          By default the seccomp profile is not enabled.
+        scored: false
+
+  - id: 4.3
+    text: "kube-proxy"
+    checks:
+      - id: 4.3.1
+        text: "Ensure that the kube-proxy metrics service is bound to localhost
+          (Automated)"
+        audit: "/bin/ps -fC $proxybin"
+        audit_config: "/bin/sh -c 'if test -e $proxykubeconfig; then cat
+          $proxykubeconfig; fi'"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--metrics-bind-address"
+              path: "{.metricsBindAddress}"
+              compare:
+                op: has
+                value: "127.0.0.1"
+            - flag: "--metrics-bind-address"
+              path: "{.metricsBindAddress}"
+              set: false
+        remediation: |
+          Modify or remove any values which bind the metrics service to a non-localhost address.
+          The default value is 127.0.0.1:10249.
+        scored: true


### PR DESCRIPTION
ROKS v4.21 CIS Benchmark results were derived using benchmark version 1.12.

This PR adds the corresponding public sample. (And a readme file.)